### PR TITLE
Change strings to template literals in injector

### DIFF
--- a/injectors/main.js
+++ b/injectors/main.js
@@ -20,7 +20,7 @@ exports.inject = async ({ getAppDir }) => {
   await Promise.all([
     writeFile(
       join(appDir, 'index.js'),
-      `require('${__dirname.replace(RegExp(sep.repeat(2), 'g'), '/')}/../src/patcher.js')`
+      `require(\`${__dirname.replace(RegExp(sep.repeat(2), 'g'), '/')}/../src/patcher.js\`)`
     ),
     writeFile(
       join(appDir, 'package.json'),


### PR DESCRIPTION
This PR fixes a bug that would cause the injector to fail if the path contained apostrophes by changing the require path to include template literals instead of apostrophes.