### PR TITLE
Local track and unloaded track error.

### DIFF
--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -35,7 +35,7 @@ module.exports = class Modal extends React.Component {
   }
 
   updateData (playerState) {
-    if (playerState && playerState.currently_playing_type != 'unknown') {
+    if (playerState && playerState.currently_playing_type !== 'unknown') {
       return this.setState({
         currentItem: {
           name: playerState.item.name,

--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -35,12 +35,12 @@ module.exports = class Modal extends React.Component {
   }
 
   updateData (playerState) {
-    if (playerState) {
+    if (playerState && playerState.currently_playing_type != 'unknown') {
       return this.setState({
         currentItem: {
           name: playerState.item.name,
           artists: playerState.item.artists.map(artist => artist.name),
-          img: playerState.item.album.images[0].url,
+          img: !playerState.item.is_local ? playerState.item.album.images[0].url : null,
           albumName: playerState.item.album.name,
           url: playerState.item.external_urls.spotify,
           uri: playerState.item.uri,


### PR DESCRIPTION
Allows for the local track to be shown, wasn't sure what to set the image to so left it null for now.
The other error was when `playerState` sometimes showed as "unknown" and didn't contain the required data so threw an error, tended to happen when Spotify hadn't loaded any tracks.