### PR TITLE
Emote Utility Update

### DIFF
--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -1,0 +1,87 @@
+const { React } = require('powercord/webpack');
+const { SwitchItem, TextInput } = require('powercord/components/settings');
+const { existsSync, lstatSync } = require('fs');
+
+module.exports = class EmojiUtilitySettings extends React.Component {
+  constructor (props) {
+    super();
+
+    this.settings = props.settings;
+    this.state = {
+      useEmbeds: props.settings.get('useEmbeds', true),
+      displayLink: props.settings.get('displayLink', true),
+      filePath: props.settings.get('filePath', null),
+      
+      isFilePathValid: props.settings.get('filePath') ? existsSync(props.settings.get('filePath')) : true,
+      initialFilePathValue: props.settings.get('filePath')
+    };
+  }
+
+  render () {
+    const settings = this.state;
+
+    const set = (key, value = !settings[key], defaultValue) => {
+      if (!value && defaultValue) {
+        value = defaultValue;
+      }
+
+      this.settings.set(key, value);
+      this.setState({
+        [key]: value
+      });
+    };
+
+    return (
+      <div>
+        <SwitchItem
+          note='Whether Emote Utility should return responses in embeds.'
+          value={settings.useEmbeds}
+          onChange={() => set('useEmbeds')}
+        >
+          Use embeds
+        </SwitchItem>
+
+        {
+          (() => {
+            if(settings.useEmbeds) {
+              return;
+            }
+
+            return (
+              <SwitchItem
+                note='Whether the message for the findemote command should contain the link to the guild the emote is in.'
+                value={settings.displayLink}
+                onChange={() => set('displayLink')}
+              >
+                Display link
+              </SwitchItem>
+            )
+          })()
+        }
+
+        <TextInput
+          note='The file path emotes should be saved to when using the saveemote command'
+          defaultValue={settings.filePath}
+          style={!this.state.isFilePathValid ? {borderColor: 'red'} : {}}
+          onChange={(value) => {
+            if(value.length === 0 || (existsSync(value) && lstatSync(value).isDirectory())) {
+              this.setState({
+                isFilePathValid: true
+              });
+
+              set('filePath', value.length === 0 ? null : value);
+            }else{
+              this.setState({
+                isFilePathValid: false
+              });
+
+              set('filePath', this.state.initialFilePathValue);
+            }
+          }}
+        >
+          File path
+        </TextInput>
+      </div>
+    );
+  }
+};

--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -11,6 +11,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
       useEmbeds: props.settings.get('useEmbeds', true),
       displayLink: props.settings.get('displayLink', true),
       filePath: props.settings.get('filePath', null),
+      includeIdForSavedEmojis: props.settings.get('includeIdForSavedEmojis', true),
       
       isFilePathValid: props.settings.get('filePath') ? existsSync(props.settings.get('filePath')) : true,
       initialFilePathValue: props.settings.get('filePath')
@@ -81,6 +82,14 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         >
           Save directory
         </TextInput>
+
+        <SwitchItem
+          note='Whether the saveemote command should include the id of the emotes it saves'
+          value={settings.includeIdForSavedEmojis}
+          onChange={() => set('includeIdForSavedEmojis')}
+        >
+          Include ID when saving emotes
+        </SwitchItem>
       </div>
     );
   }

--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -60,7 +60,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         }
 
         <TextInput
-          note='The file path emotes should be saved to when using the saveemote command'
+          note='The directory emotes will be saved to when using the saveemote command'
           defaultValue={settings.filePath}
           style={!this.state.isFilePathValid ? {borderColor: 'red'} : {}}
           onChange={(value) => {
@@ -79,7 +79,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
             }
           }}
         >
-          File path
+          Save directory
         </TextInput>
       </div>
     );

--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -49,22 +49,13 @@ module.exports = class EmojiUtilitySettings extends React.Component {
           Use embeds
         </SwitchItem>
 
-        {
-          (() => {
-            if(settings.useEmbeds) {
-              return;
-            }
-
-            return (
-              <SwitchItem
-                note='Whether the message for the findemote command should contain the link to the guild the emote is in.'
-                value={settings.displayLink}
-                onChange={() => set('displayLink')}
-              >
-                Display link
-              </SwitchItem>
-            )
-          })()
+        {!settings.useEmbeds && <SwitchItem
+            note='Whether the message for the findemote command should contain the link to the guild the emote is in.'
+            value={settings.displayLink}
+            onChange={() => set('displayLink')}
+          >
+            Display link
+          </SwitchItem>
         }
 
         <TextInput
@@ -106,37 +97,28 @@ module.exports = class EmojiUtilitySettings extends React.Component {
           Use current server when cloning emotes
         </SwitchItem>
 
-        {
-          (() => {
-            if(settings.defaultCloneIdUseCurrent) {
-              return;
-            }
+        {!settings.defaultCloneIdUseCurrent && <TextInput
+            note='The default server id which will be used to save cloned emotes with the cloneemote command if a server argument is not present'
+            defaultValue={settings.defaultCloneGuildId}
+            style={!this.state.isCloneIdValid ? {borderColor: 'red'} : {}}
+            onChange={(value) => {
+              if(value.length === 0 || getGuild(value)) {
+                this.setState({
+                  isCloneIdValid: true
+                });
 
-            return(
-              <TextInput
-                note='The default server id which will be used to save cloned emotes with the cloneemote command if a server argument is not present'
-                defaultValue={settings.defaultCloneGuildId}
-                style={!this.state.isCloneIdValid ? {borderColor: 'red'} : {}}
-                onChange={(value) => {
-                  if(value.length === 0 || getGuild(value)) {
-                    this.setState({
-                      isCloneIdValid: true
-                    });
-      
-                    set('defaultCloneId', value.length === 0 ? null : value);
-                  }else{
-                    this.setState({
-                      isCloneIdValid: false
-                    });
-      
-                    set('defaultCloneId', this.state.initialCloneIdValue);
-                  }
-                }}
-              >
-                Default server ID when cloning emotes
-              </TextInput>
-            )
-          })()
+                set('defaultCloneId', value.length === 0 ? null : value);
+              }else{
+                this.setState({
+                  isCloneIdValid: false
+                });
+
+                set('defaultCloneId', this.state.initialCloneIdValue);
+              }
+            }}
+          >
+            Default server ID when cloning emotes
+          </TextInput>
         }
       </div>
     );

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -1,6 +1,14 @@
 const Plugin = require('powercord/Plugin');
-const { getModule, channels, constants: { Routes, APP_URL_PREFIX } } = require('powercord/webpack');
+const { getModule, channels: { getSelectedChannelState, getChannelId }, constants: { Routes, APP_URL_PREFIX }, React, messages: { createBotMessage, receiveMessage } } = require('powercord/webpack');
+
+const { existsSync, createWriteStream } = require('fs');
+const { get } = require('https');
+const { extname } = require('path');
+const { parse } = require('url');
+
 const emojiStore = getModule([ 'getGuildEmoji' ]);
+
+const Settings = require('./Settings.jsx');
 
 module.exports = class EmojiUtility extends Plugin {
   getEmojiRegex () {
@@ -8,7 +16,7 @@ module.exports = class EmojiUtility extends Plugin {
   }
 
   getGuildUrl (guild) {
-    let selectedChannel = channels.getSelectedChannelState()[guild.id];
+    let selectedChannel = getSelectedChannelState()[guild.id];
     if (!selectedChannel) {
       /* I am not sure if it can get here but just to be sure */
       selectedChannel = guild.systemChannelId;
@@ -17,7 +25,53 @@ module.exports = class EmojiUtility extends Plugin {
     return APP_URL_PREFIX + Routes.CHANNEL(guild.id, selectedChannel); // eslint-disable-line new-cap
   }
 
+  getFullEmoji (emoji) {
+    return `<${(emoji.animated ? 'a' : '')}:${emoji.name}:${emoji.id}>`;
+  }
+
+  download (url) {
+    return new Promise((resolve, reject) => {
+      get(url)
+        .on('response', (response) => resolve(response))
+        .on('error', (error) => reject(error));
+    });
+  }
+
+  write (path, stream) {
+    return new Promise((resolve, reject) => {
+      const writeStream = createWriteStream(path)
+        .on('finish', () => resolve())
+        .on('error', (error) => reject(error));
+
+      stream.pipe(writeStream);
+    });
+  }
+
+  sendBotMessage (content) {
+    const receivedMessage = createBotMessage(getChannelId(), '');
+
+    if (typeof content === 'string') {
+      receivedMessage.content = content;
+    } else {
+      receivedMessage.embeds.push(content);
+    }
+
+    return receiveMessage(receivedMessage.channel_id, receivedMessage);
+  }
+
   start () {
+    powercord
+      .pluginManager
+      .get('pc-settings')
+      .register(
+        'pc-emojiUtility',
+        'Emote Utility',
+        () =>
+          React.createElement(Settings, {
+            settings: this.settings
+          })
+      );
+
     powercord
       .pluginManager
       .get('pc-commands')
@@ -29,15 +83,17 @@ module.exports = class EmojiUtility extends Plugin {
           if (args.length === 0) {
             return {
               send: false,
-              result: {
-                type: 'rich',
-                description: 'Please provide an emote',
-                color: 16711680
-              }
+              result: this.settings.get('useEmbeds')
+                ? {
+                  type: 'rich',
+                  description: 'Please provide an emote',
+                  color: 16711680
+                }
+                : 'Please provide an emote'
             };
           }
 
-          const emojis = Object.values(emojiStore.getGuilds()).flatMap(r => r.emojis);
+          const emojis = [ ...new Set(Object.values(emojiStore.getGuilds()).flatMap(r => r.emojis)) ];
 
           const foundEmojis = [];
           const notFoundEmojis = [];
@@ -50,22 +106,7 @@ module.exports = class EmojiUtility extends Plugin {
               if (emoji) {
                 const guild = getModule([ 'getGuild' ]).getGuild(emoji.guildId);
 
-                if (args.length === 1) {
-                  return {
-                    send: false,
-                    result: {
-                      type: 'rich',
-                      description: `${argument} is from **[${guild.name}](${this.getGuildUrl(guild)})**`,
-                      color: 65280,
-                      footer: {
-                        text: `Guild: ${guild.id}`
-                      }
-                    }
-                  };
-                }
-
                 foundEmojis.push({
-                  name: argument,
                   emoji,
                   guild
                 });
@@ -76,11 +117,13 @@ module.exports = class EmojiUtility extends Plugin {
               if (args.length === 1) {
                 return {
                   send: false,
-                  result: {
-                    type: 'rich',
-                    description: `Could not find emote ${argument}`,
-                    color: 16711680
-                  }
+                  result: this.settings.get('useEmbeds')
+                    ? {
+                      type: 'rich',
+                      description: `Could not find emote ${argument}`,
+                      color: 16711680
+                    }
+                    : `Could not find emote ${argument}`
                 };
               }
             }
@@ -88,30 +131,43 @@ module.exports = class EmojiUtility extends Plugin {
             if (args.length === 1) {
               return {
                 send: false,
-                result: {
-                  type: 'rich',
-                  description: `**${argument}** is not a custom emote`,
-                  color: 16711680
-                }
+                result: this.settings.get('useEmbeds')
+                  ? {
+                    type: 'rich',
+                    description: `**${argument}** is not a custom emote`,
+                    color: 16711680
+                  }
+                  : `**${argument}** is not a custom emote`
               };
             }
 
             notFoundEmojis.push(argument);
           }
 
-          let description = '';
-          for (const found of foundEmojis) {
-            description += `${found.name} is from **[${found.guild.name}](${this.getGuildUrl(found.guild)})**\n`;
+          if (this.settings.get('useEmbeds')) {
+            return {
+              send: false,
+              result: {
+                type: 'rich',
+                description: foundEmojis.map(found => `${this.getFullEmoji(found.emoji)} is from **[${found.guild.name}](${this.getGuildUrl(found.guild)})**`).join('\n'),
+                color: 65280,
+                footer: notFoundEmojis.length > 0
+                  ? {
+                    text: `${notFoundEmojis.length} of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}`
+                  }
+                  : null
+              }
+            };
+          }
+
+          let description = foundEmojis.map(found => `${this.getFullEmoji(found.emoji)} is from **${found.guild.name}**${this.settings.get('displayLink') ? ` (**${this.getGuildUrl(found.guild)}**)` : ''}`).join('\n');
+          if (notFoundEmojis.length > 0) {
+            description += `${description.length > 0 ? '\n\n' : ''}**${notFoundEmojis.length}** of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}`;
           }
 
           return {
             send: false,
-            result: {
-              type: 'rich',
-              description: description.trim(),
-              color: 65280,
-              footer: notFoundEmojis.length > 0 ? { text: `${notFoundEmojis.length} of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}` } : null
-            }
+            result: description
           };
         }
       );
@@ -128,11 +184,13 @@ module.exports = class EmojiUtility extends Plugin {
           if (argument.length === 0) {
             return {
               send: false,
-              result: {
-                type: 'rich',
-                description: 'Please provide an emote name',
-                color: 16711680
-              }
+              result: this.settings.get('useEmbeds')
+                ? {
+                  type: 'rich',
+                  description: 'Please provide an emote name',
+                  color: 16711680
+                }
+                : 'Please provide an emote name'
             };
           }
 
@@ -140,7 +198,7 @@ module.exports = class EmojiUtility extends Plugin {
 
           const foundEmojis = emojis.filter(emoji => emoji.name.toLowerCase().includes(argument));
           if (foundEmojis.length > 0) {
-            const emojisAsString = foundEmojis.map(emoji => `<${(emoji.animated ? 'a' : '')}:${emoji.name}:${emoji.id}>`).join('');
+            const emojisAsString = foundEmojis.map(emoji => this.getFullEmoji(emoji)).join('');
             if (emojisAsString.length > 2000) {
               return {
                 send: false,
@@ -153,14 +211,187 @@ module.exports = class EmojiUtility extends Plugin {
               result: emojisAsString
             };
           }
+
           return {
             send: false,
-            result: {
-              type: 'rich',
-              description: `Could not find any emotes containing **${argument}**`,
-              color: 16711680
-            }
+            result: this.settings.get('useEmbeds')
+              ? {
+                type: 'rich',
+                description: `Could not find any emotes containing **${argument}**`,
+                color: 16711680
+              }
+              : `Could not find any emotes containing **${argument}**`
           };
+        }
+      );
+
+    powercord
+      .pluginManager
+      .get('pc-commands')
+      .register(
+        'saveemote',
+        'Save emotes to a specified file path',
+        '{c} [emote]',
+        async (args) => {
+          let filePath = this.settings.get('filePath');
+
+          if (!filePath) {
+            return {
+              send: false,
+              result: this.settings.get('useEmbeds')
+                ? {
+                  type: 'rich',
+                  description: 'Please set your save file path in the settings',
+                  color: 16711680
+                }
+                : 'Please set your save file path in the settings'
+            };
+          }
+
+          if (!filePath.endsWith('/')) {
+            filePath += '/';
+          }
+
+          if (!existsSync(filePath)) {
+            return {
+              send: false,
+              result: this.settings.get('useEmbeds')
+                ? {
+                  type: 'rich',
+                  description: 'The specified file path does no longer exist, please update it in the settings',
+                  color: 16711680
+                }
+                : 'The specified file path does no longer exist, please update it in the settings'
+            };
+          }
+
+          if (args.length === 0) {
+            return {
+              send: false,
+              result: this.settings.get('useEmbeds')
+                ? {
+                  type: 'rich',
+                  description: 'Please provide an emote',
+                  color: 16711680
+                }
+                : 'Please provide an emote'
+            };
+          }
+
+          const emojis = [ ...new Set(Object.values(emojiStore.getGuilds()).flatMap(r => r.emojis)) ];
+
+          const foundEmojis = [];
+          const notFoundEmojis = [];
+
+          for (const argument of args) {
+            const matcher = argument.match(this.getEmojiRegex());
+            if (matcher) {
+              const emoji = emojis.find(e => e.id === matcher[2]);
+              if (emoji) {
+                foundEmojis.push(emoji);
+
+                continue;
+              }
+
+              if (args.length === 1) {
+                return {
+                  send: false,
+                  result: this.settings.get('useEmbeds')
+                    ? {
+                      type: 'rich',
+                      description: `Could not find emote ${argument}`,
+                      color: 16711680
+                    }
+                    : `Could not find emote ${argument}`
+                };
+              }
+            }
+
+            if (args.length === 1) {
+              return {
+                send: false,
+                result: this.settings.get('useEmbeds')
+                  ? {
+                    type: 'rich',
+                    description: `**${argument}** is not a custom emote`,
+                    color: 16711680
+                  }
+                  : `**${argument}** is not a custom emote`
+              };
+            }
+
+            notFoundEmojis.push(argument);
+          }
+
+          if (notFoundEmojis.length > 0) {
+            this.sendBotMessage(this.settings.get('useEmbeds')
+              ? {
+                type: 'rich',
+                description: `**${notFoundEmojis.length}** of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}`,
+                color: 16711680
+              }
+              : `**${notFoundEmojis.length}** of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}`
+            );
+          }
+
+          if (foundEmojis.length < 5) {
+            for (const emoji of foundEmojis) {
+              try {
+                await this.write(filePath + emoji.name + extname(parse(emoji.url).pathname), await this.download(emoji.url));
+
+                this.sendBotMessage(this.settings.get('useEmbeds')
+                  ? {
+                    type: 'rich',
+                    description: `Downloaded ${this.getFullEmoji(emoji)}`,
+                    color: 65280
+                  }
+                  : `Downloaded ${this.getFullEmoji(emoji)}`
+                );
+              } catch (error) {
+                console.error(error);
+
+                this.sendBotMessage(this.settings.get('useEmbeds')
+                  ? {
+                    type: 'rich',
+                    description: `Failed to download ${this.getFullEmoji(emoji)}`,
+                    footer: 'Check the console for more information',
+                    color: 16711680
+                  }
+                  : `Failed to download ${this.getFullEmoji(emoji)}, check the console for more information`
+                );
+              }
+            }
+          } else {
+            this.sendBotMessage(this.settings.get('useEmbeds')
+              ? {
+                type: 'rich',
+                description: `Downloading **${foundEmojis.length}** emotes, I will report back to you when I am done`,
+                color: 65280
+              }
+              : `Downloading **${foundEmojis.length}** emotes, I will report back to you when I am done`
+            );
+
+            const failedDownloads = [];
+
+            for (const emoji of foundEmojis) {
+              try {
+                await this.write(filePath + emoji.name + extname(parse(emoji.url).pathname), await this.download(emoji.url));
+              } catch (error) {
+                console.error(error);
+
+                failedDownloads.push(emoji);
+              }
+            }
+
+            this.sendBotMessage(this.settings.get('useEmbeds')
+              ? {
+                type: 'rich',
+                description: `Successfully downloaded **${foundEmojis.length - failedDownloads.length}**/**${foundEmojis.length}** emotes`,
+                color: 65280
+              }
+              : `Successfully downloaded **${foundEmojis.length - failedDownloads.length}**/**${foundEmojis.length}** emotes`
+            );
+          }
         }
       );
   }

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -311,7 +311,9 @@ module.exports = class EmojiUtility extends Plugin {
           if (foundEmojis.length < 5) {
             for (const emoji of foundEmojis) {
               try {
-                await writeFile(resolve(this.settings.get('filePath'), emoji.name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
+                const name = this.settings.get('includeIdForSavedEmojis') ? `${emoji.name} (${emoji.id})` : emoji.name;
+
+                await writeFile(resolve(this.settings.get('filePath'), name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
 
                 this.sendBotMessage(this.settings.get('useEmbeds')
                   ? {
@@ -351,7 +353,9 @@ module.exports = class EmojiUtility extends Plugin {
 
             for (const emoji of foundEmojis) {
               try {
-                await writeFile(resolve(this.settings.get('filePath'), emoji.name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
+                const name = this.settings.get('includeIdForSavedEmojis') ? `${emoji.name} (${emoji.id})` : emoji.name;
+
+                await writeFile(resolve(this.settings.get('filePath'), name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
               } catch (error) {
                 console.error(error);
 

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -7,6 +7,16 @@ module.exports = class EmojiUtility extends Plugin {
     return /^<a?:([a-zA-Z0-9_]+):([0-9]+)>$/;
   }
 
+  getGuildUrl (guild) {
+    let selectedChannel = channels.getSelectedChannelState()[guild.id];
+    if (!selectedChannel) {
+      /* I am not sure if it can get here but just to be sure */
+      selectedChannel = guild.systemChannelId;
+    }
+
+    return APP_URL_PREFIX + Routes.CHANNEL(guild.id, selectedChannel); // eslint-disable-line new-cap
+  }
+
   start () {
     powercord
       .pluginManager
@@ -16,8 +26,7 @@ module.exports = class EmojiUtility extends Plugin {
         'Find the server an emote is from',
         '{c} [emote]',
         (args) => {
-          const argument = args.join(' ');
-          if (argument.length === 0) {
+          if (args.length === 0) {
             return {
               send: false,
               result: {
@@ -28,49 +37,80 @@ module.exports = class EmojiUtility extends Plugin {
             };
           }
 
-          const matcher = argument.match(this.getEmojiRegex());
-          if (matcher) {
-            const emojis = Object.values(emojiStore.getGuilds()).flatMap(r => r.emojis);
-            const emoji = emojis.find(e => e.id === matcher[2]);
+          const emojis = Object.values(emojiStore.getGuilds()).flatMap(r => r.emojis);
 
-            if (emoji) {
-              const guild = getModule([ 'getGuild' ]).getGuild(emoji.guildId);
+          const foundEmojis = [];
+          const notFoundEmojis = [];
 
-              let selectedChannel = channels.getSelectedChannelState()[guild.id];
-              if (!selectedChannel) {
-                /* I am not sure if it can get here but just to be sure */
-                selectedChannel = guild.systemChannelId;
+          for (const argument of args) {
+            const matcher = argument.match(this.getEmojiRegex());
+            if (matcher) {
+              const emoji = emojis.find(e => e.id === matcher[2]);
+
+              if (emoji) {
+                const guild = getModule([ 'getGuild' ]).getGuild(emoji.guildId);
+
+                if (args.length === 1) {
+                  return {
+                    send: false,
+                    result: {
+                      type: 'rich',
+                      description: `${argument} is from **[${guild.name}](${this.getGuildUrl(guild)})**`,
+                      color: 65280,
+                      footer: {
+                        text: `Guild: ${guild.id}`
+                      }
+                    }
+                  };
+                }
+
+                foundEmojis.push({
+                  name: argument,
+                  emoji,
+                  guild
+                });
+
+                continue;
               }
 
-              const url = APP_URL_PREFIX + Routes.CHANNEL(guild.id, selectedChannel); // eslint-disable-line new-cap
+              if (args.length === 1) {
+                return {
+                  send: false,
+                  result: {
+                    type: 'rich',
+                    description: `Could not find emote ${argument}`,
+                    color: 16711680
+                  }
+                };
+              }
+            }
 
+            if (args.length === 1) {
               return {
                 send: false,
                 result: {
                   type: 'rich',
-                  description: `${argument} is from **[${guild.name}](${url})**`,
-                  color: 65280,
-                  footer: {
-                    text: `Guild: ${guild.id}`
-                  }
+                  description: `**${argument}** is not a custom emote`,
+                  color: 16711680
                 }
               };
             }
-            return {
-              send: false,
-              result: {
-                type: 'rich',
-                description: `Could not find emote ${argument}`,
-                color: 16711680
-              }
-            };
+
+            notFoundEmojis.push(argument);
           }
+
+          let description = '';
+          for (const found of foundEmojis) {
+            description += `${found.name} is from **[${found.guild.name}](${this.getGuildUrl(found.guild)})**\n`;
+          }
+
           return {
             send: false,
             result: {
               type: 'rich',
-              description: `**${argument}** is not a custom emote`,
-              color: 16711680
+              description: description.trim(),
+              color: 65280,
+              footer: notFoundEmojis.length > 0 ? { text: `${notFoundEmojis.length} of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}` } : null
             }
           };
         }
@@ -100,7 +140,7 @@ module.exports = class EmojiUtility extends Plugin {
 
           const foundEmojis = emojis.filter(emoji => emoji.name.toLowerCase().includes(argument));
           if (foundEmojis.length > 0) {
-            const emojisAsString = foundEmojis.map(emoji => `<${(emoji.animated ? 'a' : '') + emoji.allNamesString + emoji.id}>`).join('');
+            const emojisAsString = foundEmojis.map(emoji => `<${(emoji.animated ? 'a' : '')}:${emoji.name}:${emoji.id}>`).join('');
             if (emojisAsString.length > 2000) {
               return {
                 send: false,

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -230,9 +230,9 @@ module.exports = class EmojiUtility extends Plugin {
       .get('pc-commands')
       .register(
         'saveemote',
-        'Save emotes to a specified file path',
+        'Save emotes to a specified directory',
         '{c} [emote]',
-        async (args) => {
+        async (args) => { // eslint-disable-line complexity
           let filePath = this.settings.get('filePath');
 
           if (!filePath) {
@@ -241,10 +241,10 @@ module.exports = class EmojiUtility extends Plugin {
               result: this.settings.get('useEmbeds')
                 ? {
                   type: 'rich',
-                  description: 'Please set your save file path in the settings',
+                  description: 'Please set your save directory in the settings',
                   color: 16711680
                 }
-                : 'Please set your save file path in the settings'
+                : 'Please set your save directory in the settings'
             };
           }
 
@@ -258,10 +258,10 @@ module.exports = class EmojiUtility extends Plugin {
               result: this.settings.get('useEmbeds')
                 ? {
                   type: 'rich',
-                  description: 'The specified file path does no longer exist, please update it in the settings',
+                  description: 'The specified save directory does no longer exist, please update it in the settings',
                   color: 16711680
                 }
-                : 'The specified file path does no longer exist, please update it in the settings'
+                : 'The specified save directory does no longer exist, please update it in the settings'
             };
           }
 

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -17,6 +17,16 @@ module.exports = class EmojiUtility extends Plugin {
         '{c} [emote]',
         (args) => {
           const argument = args.join(' ');
+          if (argument.length == 0) {
+            return {
+              send: false,
+              result: {
+                type: 'rich',
+                description: 'Please provide an emote',
+                color: 16711680
+              }
+            };
+          }
 
           const matcher = argument.match(this.getEmojiRegex());
           if (matcher) {
@@ -50,7 +60,7 @@ module.exports = class EmojiUtility extends Plugin {
               send: false,
               result: {
                 type: 'rich',
-                description: `Could not find emote ${argument}!`,
+                description: `Could not find emote ${argument}`,
                 color: 16711680
               }
             };
@@ -59,7 +69,7 @@ module.exports = class EmojiUtility extends Plugin {
             send: false,
             result: {
               type: 'rich',
-              description: `**${argument}** is not a custom emote!`,
+              description: `**${argument}** is not a custom emote`,
               color: 16711680
             }
           };
@@ -88,7 +98,7 @@ module.exports = class EmojiUtility extends Plugin {
             send: false,
             result: {
               type: 'rich',
-              description: `Could not find any emotes containing **${argument}**!`,
+              description: `Could not find any emotes containing **${argument}**`,
               color: 16711680
             }
           };

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -105,7 +105,7 @@ module.exports = class EmojiUtility extends Plugin {
     return {
       foundEmojis,
       notFoundEmojis
-    }
+    };
   }
 
   start () {
@@ -134,8 +134,7 @@ module.exports = class EmojiUtility extends Plugin {
             return object;
           }
 
-          const foundEmojis = object.foundEmojis;
-          const notFoundEmojis = object.notFoundEmojis;
+          const { foundEmojis, notFoundEmojis } = object;
 
           if (this.settings.get('useEmbeds')) {
             return {
@@ -257,8 +256,7 @@ module.exports = class EmojiUtility extends Plugin {
             return object;
           }
 
-          const foundEmojis = object.foundEmojis;
-          const notFoundEmojis = object.notFoundEmojis;
+          const { foundEmojis, notFoundEmojis } = object;
 
           if (notFoundEmojis.length > 0) {
             this.sendBotMessage(this.settings.get('useEmbeds')

--- a/src/Powercord/plugins/pc-emojiUtility/manifest.json
+++ b/src/Powercord/plugins/pc-emojiUtility/manifest.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repo": null,
   "dependencies": [
-    "pc-commands"
+    "pc-commands",
+    "pc-settings"
   ]
 }

--- a/src/Powercord/plugins/pc-emojiUtility/manifest.json
+++ b/src/Powercord/plugins/pc-emojiUtility/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Emote Utility",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Emote related commands",
   "author": "Joakim#9814",
   "license": "MIT",

--- a/src/Powercord/plugins/pc-emojiUtility/manifest.json
+++ b/src/Powercord/plugins/pc-emojiUtility/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Emote Utility",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Emote related commands",
   "author": "Joakim#9814",
   "license": "MIT",


### PR DESCRIPTION
* Changes
  * Changed the command "find" to a less generic name "findemote".

</br>

* New features
  * You can now input multiple emotes in to "findemote"
  * You can now use the "saveemote" command to save emotes to a pre-defined directory
  * You can now use the "cloneemote" command to clone emotes to your own server (The server argument can default to the current guild or a pre-defined guild, check the settings)

</br>

* Added settings for
  * Responding with embeds or not
    * Setting to have a link to the guild in "findemote" when this is disabled
  * Set a save directory for the "saveemote" command
  * Use current guild when cloning emotes
    * Or set a pre-defined guild 