### PR TITLE
Emote Utility update

### DIFF
--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -21,7 +21,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
       initialFilePathValue: props.settings.get('filePath'),
 
       isCloneIdValid: props.settings.get('defaultCloneId') ? getGuild(props.settings.get('defaultCloneId')) : true,
-      initialCloneIdValue: props.settings.get('defaultCloneId')
+      initialCloneIdValue: props.settings.get('defaultCloneId') ? props.settings.get('defaultCloneId') : null
     };
   }
 
@@ -60,7 +60,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         )}
 
         <TextInput
-          note='The directory emotes will be saved to when using the saveemote command'
+          note='The directory emotes will be saved to.'
           defaultValue={settings.filePath}
           style={!this.state.isFilePathValid ? { borderColor: 'red' } : {}}
           onChange={(value) => {
@@ -83,7 +83,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         </TextInput>
 
         <SwitchItem
-          note='Whether the saveemote command should include the id of the emotes it saves'
+          note='Whether saving emotes should contain the id of the emote, this prevents overwriting old saved emotes.'
           value={settings.includeIdForSavedEmojis}
           onChange={() => set('includeIdForSavedEmojis')}
         >
@@ -91,7 +91,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         </SwitchItem>
 
         <SwitchItem
-          note='Whether the default server id for the cloneemote command should be the server you are currently in if a server argument is not present'
+          note='Whether the default server for cloning emotes should be the server you are currently in.'
           value={settings.defaultCloneIdUseCurrent}
           onChange={() => set('defaultCloneIdUseCurrent')}
         >
@@ -100,8 +100,8 @@ module.exports = class EmojiUtilitySettings extends React.Component {
 
         {!settings.defaultCloneIdUseCurrent && (
           <TextInput
-            note='The default server id which will be used to save cloned emotes with the cloneemote command if a server argument is not present'
-            defaultValue={settings.defaultCloneGuildId}
+            note='The default server id which will be used to save cloned emotes.'
+            defaultValue={settings.defaultCloneId}
             style={!this.state.isCloneIdValid ? { borderColor: 'red' } : {}}
             onChange={(value) => {
               if (value.length === 0 || getGuild(value)) {

--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -11,10 +11,10 @@ module.exports = class EmojiUtilitySettings extends React.Component {
     this.settings = props.settings;
     this.state = Object.assign({
       isFilePathValid: props.settings.get('filePath') ? existsSync(props.settings.get('filePath')) : true,
-      initialFilePathValue: props.settings.get('filePath') ? props.settings.get('filePath') : null,
+      initialFilePathValue: props.settings.get('filePath') || null,
 
       isCloneIdValid: props.settings.get('defaultCloneId') ? getGuild(props.settings.get('defaultCloneId')) : true,
-      initialCloneIdValue: props.settings.get('defaultCloneId') ? props.settings.get('defaultCloneId') : null
+      initialCloneIdValue: props.settings.get('defaultCloneId') || null
     }, this.settings.config);
   }
 

--- a/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/Settings.jsx
@@ -9,20 +9,13 @@ module.exports = class EmojiUtilitySettings extends React.Component {
     super();
 
     this.settings = props.settings;
-    this.state = {
-      useEmbeds: props.settings.get('useEmbeds', true),
-      displayLink: props.settings.get('displayLink', true),
-      filePath: props.settings.get('filePath', null),
-      includeIdForSavedEmojis: props.settings.get('includeIdForSavedEmojis', true),
-      defaultCloneId: props.settings.get('defaultCloneId', null),
-      defaultCloneIdUseCurrent: props.settings.get('defaultCloneIdUseCurrent', false),
-
+    this.state = Object.assign({
       isFilePathValid: props.settings.get('filePath') ? existsSync(props.settings.get('filePath')) : true,
-      initialFilePathValue: props.settings.get('filePath'),
+      initialFilePathValue: props.settings.get('filePath') ? props.settings.get('filePath') : null,
 
       isCloneIdValid: props.settings.get('defaultCloneId') ? getGuild(props.settings.get('defaultCloneId')) : true,
       initialCloneIdValue: props.settings.get('defaultCloneId') ? props.settings.get('defaultCloneId') : null
-    };
+    }, this.settings.config);
   }
 
   render () {

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -360,9 +360,10 @@ module.exports = class EmojiUtility extends Plugin {
     });
 
     const EmojiNameModal = require('./EmojiNameModal.jsx');
-    inject('pc-emojiUtility-imageContext', MessageContextMenu.prototype, 'render', function (args, res) { // eslint-disable-line func-names
+    const handleImageContext = function (args, res) {
       const { target } = this.props;
-      if (target.parentElement.classList.contains('pc-embedWrapper')) {
+
+      if (target.tagName.toLowerCase() === 'img' && target.parentElement.classList.contains('pc-imageWrapper')) {
         const onGuildClick = (guild) => {
           if (!guild) {
             if (_this.settings.get('defaultCloneIdUseCurrent')) {
@@ -450,6 +451,14 @@ module.exports = class EmojiUtility extends Plugin {
           return features;
         };
 
+        /* NativeContextMenu's children is a single object, turn it in to an array to be able to push */
+        if (typeof res.props.children === 'object') {
+          const children = [];
+          children.push(res.props.children);
+
+          res.props.children = children;
+        }
+
         res.props.children.push(
           React.createElement(Submenu, {
             name: 'Emote',
@@ -460,7 +469,12 @@ module.exports = class EmojiUtility extends Plugin {
       }
 
       return res;
-    });
+    };
+
+    inject('pc-emojiUtility-imageContext', MessageContextMenu.prototype, 'render', handleImageContext); // eslint-disable-line func-names
+
+    const NativeContextMenu = getModuleByDisplayName('NativeContextMenu');
+    inject('pc-emojiUtility-nativeContext', NativeContextMenu.prototype, 'render', handleImageContext); // eslint-disable-line func-names
 
     powercord
       .pluginManager
@@ -707,6 +721,7 @@ module.exports = class EmojiUtility extends Plugin {
 
     uninject('pc-emojiUtility-emojiContext');
     uninject('pc-emojiUtility-imageContext');
+    uninject('pc-emojiUtility-nativeContext');
 
     const { pluginManager } = powercord;
 

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -511,7 +511,7 @@ module.exports = class EmojiUtility extends Plugin {
               };
             }
 
-            if (getCurrentUser().premiumType === 0) {
+            if (!getCurrentUser().premium) {
               return {
                 send: false,
                 result: `Looks like you do not have nitro, let me send that locally instead!\n${emojisAsString}`

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -185,6 +185,14 @@ module.exports = class EmojiUtility extends Plugin {
   start () {
     this.loadCSS(resolve(__dirname, 'style.scss'));
 
+    /* Default settings */
+    this.settings.set('useEmbeds', this.settings.get('useEmbeds', true));
+    this.settings.set('displayLink', this.settings.get('displayLink', true));
+    this.settings.set('filePath', this.settings.get('filePath', null));
+    this.settings.set('includeIdForSavedEmojis', this.settings.get('includeIdForSavedEmojis', true));
+    this.settings.set('defaultCloneId', this.settings.get('defaultCloneId', null));
+    this.settings.set('defaultCloneIdUseCurrent', this.settings.get('defaultCloneIdUseCurrent', false));
+
     const _this = this;
 
     const MessageContextMenu = getModuleByDisplayName('MessageContextMenu');
@@ -503,11 +511,11 @@ module.exports = class EmojiUtility extends Plugin {
               };
             }
 
-            if (getCurrentUser().premiumType == 0) {
+            if (getCurrentUser().premiumType === 0) {
               return {
                 send: false,
                 result: `Looks like you do not have nitro, let me send that locally instead!\n${emojisAsString}`
-              }
+              };
             }
 
             return {

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -10,11 +10,11 @@ const {
   },
   constants: {
     Routes,
-    APP_URL_PREFIX,
+    GuildFeatures,
     Permissions, // eslint-disable-line no-shadow
+    APP_URL_PREFIX,
     EMOJI_RE,
     EMOJI_MAX_LENGTH,
-    GuildFeatures,
     EMOJI_MAX_SLOTS,
     EMOJI_MAX_SLOTS_MORE
   },

--- a/src/Powercord/plugins/pc-emojiUtility/manifest.json
+++ b/src/Powercord/plugins/pc-emojiUtility/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Emote Utility",
-  "version": "1.2.0",
+  "version": "1.2.5",
   "description": "Emote related commands",
   "author": "Joakim#9814",
   "license": "MIT",


### PR DESCRIPTION
* Added the ability to clone/create to your default guild by pressing the submenu
* Check if the user is nitro when using the "massemote" command
* Now uses Discord's method for cleaning the name of emotes when creating a new emote from an image
* Changed some notes for the settings
* Default settings
* Added checks for the amount of emotes the guild has
* Added support for image embeds caused by links
* Added support for right-clicking reactions

* [Bug] Default guild would not show up in the settings after you had set it