### PR TITLE
[ Feature ] Role ID Copying

### DIFF
--- a/src/Powercord/plugins/pc-copyRoleID/index.js
+++ b/src/Powercord/plugins/pc-copyRoleID/index.js
@@ -1,0 +1,29 @@
+const Plugin = require('powercord/Plugin');
+const { contextMenu, getModuleByDisplayName, React } = require('powercord/webpack');
+const { ContextMenu } = require('powercord/components');
+const { inject } = require('powercord/injector');
+const { clipboard } = require('electron');
+
+// todo figure out how to do the same on UserPopOuts. Discussed with Aeth but seems to be a bit more complicated
+module.exports = class CopyRoleID extends Plugin {
+  start () {
+    const GuildRole = getModuleByDisplayName('GuildRole');
+    inject('pc-guildRole', GuildRole.prototype, 'render', (args, res) => { // eslint-disable-line func-names
+      res.props.children.props.onContextMenu = (e) => {
+        const { pageX, pageY } = e;
+        contextMenu.openContextMenu(e, () =>
+          React.createElement(ContextMenu, {
+            pageX,
+            pageY,
+            itemGroups: [ [ {
+              type: 'button',
+              name: 'Copy ID',
+              onClick: () => clipboard.writeText(res.props.id)
+            } ] ]
+          })
+        );
+      };
+      return res;
+    });
+  }
+};

--- a/src/Powercord/plugins/pc-copyRoleID/manifest.json
+++ b/src/Powercord/plugins/pc-copyRoleID/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Copy Role ID",
+  "version": "1.0.0",
+  "description": "Adds a context menu to Roles in the Server Settings that allows copying the ID.",
+  "author": "MrLar#2565",
+  "license": "MIT",
+  "repo": null
+}


### PR DESCRIPTION
Adds a context to Server settings that allows Copying the roles ID. Planned was to add it to UserPopOuts aswell but for that see todo in index.js