### PR TITLE
Do not send emote utility responses in embeds by default

### DIFF
--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -207,7 +207,7 @@ module.exports = class EmojiUtility extends Plugin {
     this.loadCSS(resolve(__dirname, 'style.scss'));
 
     /* Default settings */
-    this.settings.set('useEmbeds', this.settings.get('useEmbeds', true));
+    this.settings.set('useEmbeds', this.settings.get('useEmbeds', false));
     this.settings.set('displayLink', this.settings.get('displayLink', true));
     this.settings.set('filePath', this.settings.get('filePath', null));
     this.settings.set('includeIdForSavedEmojis', this.settings.get('includeIdForSavedEmojis', true));


### PR DESCRIPTION
This pull request switches the default behaviour for the emote utility responses to send as regular Clyde messages instead of embeds, by default, instead of embeds.

**Why?**
Emote responses from Clyde look strange as they are very different from the normal messages that Clyde sends - this brings the emote utility's behaviour back in line with how Discord uses Clyde to interact with the user.