### PR TITLE
Add retrying as a configurable parameter for getModule

### DIFF
--- a/src/fake_node_modules/powercord/webpack/index.js
+++ b/src/fake_node_modules/powercord/webpack/index.js
@@ -18,7 +18,7 @@ exports.init = async () => {
   ]);
   delete instance.cache[moduleID];
 
-  const getModule = (filter, unsuccessfulIterations = 0) => {
+  const getModule = (filter, retry = true, unsuccessfulIterations = 0) => {
     if (Array.isArray(filter)) {
       const keys = filter;
       filter = m => keys.every(key => m[key]);
@@ -37,9 +37,13 @@ exports.init = async () => {
     ));
 
     if (!mdl) {
+      if (!retry) {
+        return null;
+      }
+      
       unsuccessfulIterations++;
       return sleep(100)
-        .then(() => getModule(filter, unsuccessfulIterations));
+        .then(() => getModule(filter, true, unsuccessfulIterations));
     }
 
     return mdl.exports.default || mdl.exports;


### PR DESCRIPTION
Normally, the `getModule` would retry 16 times if it hasn't found a match, this adds a boolean parameter that lets you control whether it should retry or not.
