### PR TITLE
Repair 'Announcements' plug-in

### DIFF
--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -18,27 +18,24 @@ const Notice = class Notice extends React.Component {
   async componentDidMount () {
     if (!classesStore) {
       const classes = await getModule([ 'noticeBrand' ]);
-      Promise.all([ classes ])
-        .then(value => {
-          this.setState({
-            types: {
-              blurple: value[0].noticeBrand,
-              red: value[0].noticeDanger,
-              orange: value[0].noticeDefault,
-              facebook: value[0].noticeFacebook,
-              blue: value[0].noticeInfo,
-              dark: value[0].noticePremium,
-              blurple_gradient: value[0].noticePremiumGrandfathered,
-              spotify: value[0].noticeSpotify,
-              purple: value[0].noticeStreamerMode,
-              green: value[0].noticeSuccess,
-              survey: value[0].noticeSurvey
-            },
-            button: value[0].button,
-            dismiss: value[0].dismiss
-          });
-          classesStore = this.state;
-        });
+      this.setState({
+        types: {
+          blurple: classes.noticeBrand,
+          red: classes.noticeDanger,
+          orange: classes.noticeDefault,
+          facebook: classes.noticeFacebook,
+          blue: classes.noticeInfo,
+          dark: classes.noticePremium,
+          blurple_gradient: classes.noticePremiumGrandfathered,
+          spotify: classes.noticeSpotify,
+          purple: classes.noticeStreamerMode,
+          green: classes.noticeSuccess,
+          survey: classes.noticeSurvey
+        },
+        button: classes.button,
+        dismiss: classes.dismiss
+      });
+      classesStore = this.state;
     }
   }
 

--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -1,4 +1,4 @@
-const { React, getModule, getModuleByDisplayName } = require('powercord/webpack');
+const { React, getModule, getComponentByDisplayName } = require('powercord/webpack');
 
 const Clickable = getComponentByDisplayName('Clickable');
 
@@ -43,7 +43,7 @@ const Notice = class Notice extends React.Component {
     const { notice, onClose } = this.props;
     const { types, button, dismiss } = this.state;
 
-    return <div className={`powercord-notice ${(types[notice.type] || types.blurple)}`}>
+    return <div className={`powercord-notice ${(types[notice.type] || types.BLURPLE)}`}>
       {notice.message}
       <Clickable className={dismiss} onClick={() => onClose()}/>
       {notice.button &&

--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -1,6 +1,6 @@
 const { React, getModule, getModuleByDisplayName } = require('powercord/webpack');
 
-const Clickable = getModuleByDisplayName('Clickable');
+const Clickable = getComponentByDisplayName('Clickable');
 
 let classesStore = null;
 
@@ -20,17 +20,17 @@ const Notice = class Notice extends React.Component {
       const classes = await getModule([ 'noticeBrand' ]);
       this.setState({
         types: {
-          blurple: classes.noticeBrand,
-          red: classes.noticeDanger,
-          orange: classes.noticeDefault,
-          facebook: classes.noticeFacebook,
-          blue: classes.noticeInfo,
-          dark: classes.noticePremium,
-          blurple_gradient: classes.noticePremiumGrandfathered,
-          spotify: classes.noticeSpotify,
-          purple: classes.noticeStreamerMode,
-          green: classes.noticeSuccess,
-          survey: classes.noticeSurvey
+          BLURPLE: classes.noticeBrand,
+          RED: classes.noticeDanger,
+          ORANGE: classes.noticeDefault,
+          FACEBOOK: classes.noticeFacebook,
+          BLUE: classes.noticeInfo,
+          DARK: classes.noticePremium,
+          BLURPLE_GRADIENT: classes.noticePremiumGrandfathered,
+          SPOTIFY: classes.noticeSpotify,
+          PURPLE: classes.noticeStreamerMode,
+          GREEN: classes.noticeSuccess,
+          SURVEY: classes.noticeSurvey
         },
         button: classes.button,
         dismiss: classes.dismiss
@@ -43,7 +43,7 @@ const Notice = class Notice extends React.Component {
     const { notice, onClose } = this.props;
     const { types, button, dismiss } = this.state;
 
-    return <div className={`powercord-notice ${(types[notice.type.toLowerCase()] || types.blurple)}`}>
+    return <div className={`powercord-notice ${(types[notice.type] || types.blurple)}`}>
       {notice.message}
       <Clickable className={dismiss} onClick={() => onClose()}/>
       {notice.button &&

--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -1,33 +1,72 @@
 const { React, getModule, getModuleByDisplayName } = require('powercord/webpack');
 
 const Clickable = getModuleByDisplayName('Clickable');
-const classes = getModule([ 'noticeBrand' ]);
+
+let classesStore = null;
 
 const Notice = class Notice extends React.Component {
+  constructor () {
+    super();
+
+    this.state = classesStore || {
+      types: [],
+      button: '',
+      dismiss: ''
+    };
+  }
+
+  async componentDidMount () {
+    if (!classesStore) {
+      const classes = await getModule([ 'noticeBrand' ]);
+      Promise.all([ classes ])
+        .then(value => {
+          this.setState({
+            types: {
+              blurple: value[0].noticeBrand,
+              red: value[0].noticeDanger,
+              orange: value[0].noticeDefault,
+              facebook: value[0].noticeFacebook,
+              blue: value[0].noticeInfo,
+              dark: value[0].noticePremium,
+              blurple_gradient: value[0].noticePremiumGrandfathered,
+              spotify: value[0].noticeSpotify,
+              purple: value[0].noticeStreamerMode,
+              green: value[0].noticeSuccess,
+              survey: value[0].noticeSurvey
+            },
+            button: value[0].button,
+            dismiss: value[0].dismiss
+          });
+          classesStore = this.state;
+        });
+    }
+  }
+
   render () {
     const { notice, onClose } = this.props;
+    const { types, button, dismiss } = this.state;
 
-    return <div className={`powercord-notice ${(Notice.TYPES[notice.type] || Notice.TYPES.BLURPLE)}`}>
+    return <div className={`powercord-notice ${(types[notice.type.toLowerCase()] || types.blurple)}`}>
       {notice.message}
-      <Clickable className={classes.dismiss} onClick={() => onClose()}/>
+      <Clickable className={dismiss} onClick={() => onClose()}/>
       {notice.button &&
-      <button className={classes.button} onClick={notice.button.onClick}>{notice.button.text}</button>}
+      <button className={button} onClick={notice.button.onClick}>{notice.button.text}</button>}
     </div>;
   }
 };
 
 Notice.TYPES = {
-  BLURPLE: classes.noticeBrand,
-  RED: classes.noticeDanger,
-  ORANGE: classes.noticeDefault,
-  FACEBOOK: classes.noticeFacebook,
-  BLUE: classes.noticeInfo,
-  DARK: classes.noticePremium,
-  BLURPLE_GRADIENT: classes.noticePremiumGrandfathered,
-  SPOTIFY: classes.noticeSpotify,
-  PURPLE: classes.noticeStreamerMode,
-  GREEN: classes.noticeSuccess,
-  SURVEY: classes.noticeSurvey // noticeInfo's (Notice.TYPES.BLUE) evil twin -- hovering over the CTA button greets you with some gloomy black text instead of the traditional white.
+  BLURPLE: 'BLURPLE',
+  RED: 'RED',
+  ORANGE: 'ORANGE',
+  FACEBOOK: 'FACEBOOK',
+  BLUE: 'BLUE',
+  DARK: 'DARK',
+  BLURPLE_GRADIENT: 'BLURPLE_GRADIENT',
+  SPOTIFY: 'SPOTIFY',
+  PURPLE: 'PURPLE',
+  GREEN: 'GREEN',
+  SURVEY: 'SURVEY' // noticeInfo's (Notice.TYPES.BLUE) evil twin -- hovering over the CTA button greets you with some gloomy black text instead of the traditional white.
 };
 
 module.exports = Notice;

--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -26,7 +26,8 @@ Notice.TYPES = {
   BLURPLE_GRADIENT: classes.noticePremiumGrandfathered,
   SPOTIFY: classes.noticeSpotify,
   PURPLE: classes.noticeStreamerMode,
-  GREEN: classes.noticeSuccess
+  GREEN: classes.noticeSuccess,
+  SURVEY: classes.noticeSurvey // noticeInfo's (Notice.TYPES.BLUE) evil twin -- hovering over the CTA button greets you with some gloomy black text instead of the traditional white.
 };
 
 module.exports = Notice;

--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -7,6 +7,8 @@ const { inject, uninject } = require('powercord/injector');
 const { React, ReactDOM, getModule } = require('powercord/webpack');
 const { DISCORD_INVITE, GUILD_ID } = require('powercord/constants');
 
+const Notice = require('./Notice');
+
 module.exports = class Announcements extends Plugin {
   constructor () {
     super();
@@ -31,7 +33,7 @@ module.exports = class Announcements extends Plugin {
             });
           }
         },
-        alwaysDisplay: true,
+        alwaysDisplay: true
       });
     }
 
@@ -79,7 +81,6 @@ module.exports = class Announcements extends Plugin {
   }
 
   _renderNotice () {
-    const Notice = require('./Notice');
     if (document.querySelector('.pc-wrapper + .pc-flex > .pc-flexChild .pc-notice')) {
       return;
     }

--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -30,8 +30,9 @@ module.exports = class Announcements extends Plugin {
               getModule([ 'selectGuild' ]).selectGuild(GUILD_ID);
             });
           }
-        }
-      }, true);
+        },
+        alwaysDisplay: true,
+      });
     }
 
     this.sendNotice({
@@ -52,8 +53,7 @@ module.exports = class Announcements extends Plugin {
     uninject('pc-custom-notices');
   }
 
-  sendNotice (notice, alwaysDisplay) {
-    notice.alwaysDisplay = alwaysDisplay || false; // append a new key to the corresponding notice; we'll use this to grab the value of alwaysDisplay outside of this method
+  sendNotice (notice) {
     if (!this.notices.find(n => n.id === notice.id) && (notice.alwaysDisplay || !this.settings.get('dismissed', []).includes(notice.id))) {
       this.notices.push(notice);
       this._renderNotice();
@@ -61,10 +61,10 @@ module.exports = class Announcements extends Plugin {
   }
 
   closeNotice (noticeId) {
-    this.notices = this.notices.filter(n => n.id !== noticeId);
-    if (this.notices.find(n => n.alwaysDisplay)) { // make sure that we're only adding notices found without alwaysDisplay to the 'dismissed' array
+    if (this.notices.find(n => n.id === noticeId && !n.alwaysDisplay)) { // make sure that we're only adding notices found without alwaysDisplay to the 'dismissed' array
       this.settings.set('dismissed', [ ...this.settings.get('dismissed', []), noticeId ]);
     }
+    this.notices = this.notices.filter(n => n.id !== noticeId);
     this._renderNotice();
   }
 

--- a/src/Powercord/plugins/pc-announcements/manifest.json
+++ b/src/Powercord/plugins/pc-announcements/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Announcements",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Broadcast announcements from Powercord API or plugins",
   "author": "Powercord Team",
   "license": "MIT",


### PR DESCRIPTION
### Plugin Changelog (v0.1.1) :: Announcements
index.js:
* Add notice types to current announcements (first-welcome & pewdiepie).
* Modify message content, button text and `onClick()` method for `pc-pewdiepie`.
* Announcements that are set to `alwaysDisplay` no longer write to the "dismissed" array found in settings.
* Update query selectors to use `.pc-wrapper` class instead of `.pc-guildWrapper` as it is now obsolete.

Notice.jsx:
* Add an additional notice type based around `noticeInfo` that changes the CTA button text to black on hover.