### PR TITLE
[Spotify] Made 'line 8' of `SpotifyPlayer.js` grammatically correct

### DIFF
--- a/src/Powercord/plugins/pc-spotify/SpotifyPlayer.js
+++ b/src/Powercord/plugins/pc-spotify/SpotifyPlayer.js
@@ -5,7 +5,7 @@ const { http, spotify, constants: { Endpoints } } = require('powercord/webpack')
 
 const revokedMessages = {
   SCOPES_UPDATED: 'Your Spotify account needs to be relinked to your Powercord account due to new authorizations required.',
-  ACCESS_DENIED: 'Powercord is no longer able to connect to your Spotify account. Therefore, it have been automatically unlinked.'
+  ACCESS_DENIED: 'Powercord is no longer able to connect to your Spotify account. Therefore, it has been automatically unlinked.'
 };
 
 module.exports = {


### PR DESCRIPTION
* Fixes a possible typo/the grammatical mistake towards the end of 'line 8' - "Therefore, it **have** been automatically unlinked" is now "Therefore, it **has** been automatically unlinked".

plz dont hurt me @Bowser65 i no bulli u i vry gud man