### PR TITLE
[Announcements] Fix 'Join Server' button

### DIFF
--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -29,11 +29,13 @@ module.exports = class Announcements extends Plugin {
           text: 'Join Server',
           onClick: () => {
             this.closeNotice('pc-first-welcome');
-            if (!Object.values(getModule([ 'getGuilds' ]).getGuilds()).find(guild => guild.id === GUILD_ID)) {
-              getModule([ 'acceptInvite' ]).acceptInvite(DISCORD_INVITE);
+            if (getModule([ 'getGuilds' ]).getGuilds()[GUILD_ID]) {
+              getModule([ 'acceptInvite' ]).acceptInvite(DISCORD_INVITE, {}, () => {
+                getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
+              });
+            } else {
+              getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
             }
-
-            getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
           }
         },
         alwaysDisplay: true

--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -30,7 +30,7 @@ module.exports = class Announcements extends Plugin {
           onClick: () => {
             this.closeNotice('pc-first-welcome');
             getModule([ 'acceptInvite' ]).acceptInvite(DISCORD_INVITE, {}, () => {
-              getModule([ 'selectGuild' ]).selectGuild(GUILD_ID);
+              getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
             });
           }
         },

--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -29,9 +29,11 @@ module.exports = class Announcements extends Plugin {
           text: 'Join Server',
           onClick: () => {
             this.closeNotice('pc-first-welcome');
-            getModule([ 'acceptInvite' ]).acceptInvite(DISCORD_INVITE, {}, () => {
-              getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
-            });
+            if (!Object.values(getModule([ 'getGuilds' ]).getGuilds()).find(guild => guild.id === GUILD_ID)) {
+              getModule([ 'acceptInvite' ]).acceptInvite(DISCORD_INVITE);
+            }
+
+            getModule([ 'flushSelection' ]).selectGuild(GUILD_ID);
           }
         },
         alwaysDisplay: true


### PR DESCRIPTION
By swapping out the `selectGuild` module with `flushSelection`, this patch fixes the mishap that appears when navigating away from the 'Activity' tab moments after selecting the 'Join Server' button (shown after successfully injecting Powercord).

Thanks, @ohlookitsderpy for bringing this to my attention otherwise I never would've known about it. 😊