### PR TITLE
[DblClickEdit] Make edits 20% more friendly 🙂

### DIFF
--- a/src/Powercord/plugins/pc-dblClickEdit/index.js
+++ b/src/Powercord/plugins/pc-dblClickEdit/index.js
@@ -37,14 +37,16 @@ class DblClickEdit extends Plugin {
   }
 
   handleMessageEdit (channelId, messageId, content) {
-    return async () => {
-      const { startEditMessage } = await getModule([ 'editMessage' ]);
-      startEditMessage(channelId, messageId, content);
+    return async (e) => {
+      if (e.target.className && e.target.className.includes('pc-markup')) {
+        const editMessage = await getModule([ 'editMessage' ]).startEditMessage;
+        editMessage(channelId, messageId, content);
+      }
     };
   }
 
   /*
-   * DISCLAIMER: the following method was taken from .intrnl#6380's 'twitchEmotes'
+   * DISCLAIMER: the following method was taken from .intrnl#6380's 'blackboxTags'
    * plug-in - this snippet of code does not belong to me.
    */
   forceUpdate (query) {

--- a/src/Powercord/plugins/pc-dblClickEdit/manifest.json
+++ b/src/Powercord/plugins/pc-dblClickEdit/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Double Click Edit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Allows the author (you) to edit messages simply by double clicking on them",
   "author": "Harley#1051",
   "license": "MIT"


### PR DESCRIPTION
* Update the multi-line comment starting from line 48 to reference the correct plug-in where the method was first discovered.
* Introduce an 'if' condition that allows us to only trigger an edit if the message content (`pc-markup`) is double-clicked.
* Replace the nested object previously found on line 41 to instead use a variable called "editMessage".
* Bump version number to '0.1.1'.