### PR TITLE
Add another path to check for in Linux injector, cuz why not.

### DIFF
--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -4,7 +4,7 @@ const { join } = require('path');
 const paths = [
   '/usr/share/discord-canary',
   '/usr/lib64/discord-canary',
-  '/opt/discord-canary',
+  '/opt/discord-canary'
 ];
 
 exports.getAppDir = async () => {

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -3,7 +3,8 @@ const { join } = require('path');
 
 const paths = [
   '/usr/share/discord-canary',
-  '/opt/discord-canary'
+  '/usr/lib64/discord-canary',
+  '/opt/discord-canary',
 ];
 
 exports.getAppDir = async () => {


### PR DESCRIPTION
Discord package on RPMFusion (Fedora) installs to `/usr/lib64`

While RPMFusion doesn't have Canary builds _yet_, it might be wise just to be sure.