### PR TITLE
Fix typo causing settings to not sync.

### DIFF
--- a/src/Powercord/apis/settings/index.js
+++ b/src/Powercord/apis/settings/index.js
@@ -136,7 +136,7 @@ module.exports = class Settings extends API {
     const token = this.store.getSetting('pc-general', 'powercordToken');
     const baseUrl = this.store.getSetting('pc-general', 'backendURL', WEBSITE);
 
-    let { isEncrypted, payload: settings } = (await get(`${baseUrl}/api/users/@me/settings`)
+    let { isEncrypted, powercord: settings } = (await get(`${baseUrl}/api/users/@me/settings`)
       .set('Authorization', token)
       .then(r => r.body));
 


### PR DESCRIPTION
Was causing this error to occur before.
```
[Powercord:SettingsManager] Unable to sync settings! SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at Settings.download (/Users/X/Downloads/Discord/powercord/src/Powercord/apis/settings/index.js:158)
```