### PR TITLE
Update WIP Warning in the Powercord Plugins Settings

### DIFF
--- a/src/Powercord/plugins/pc-pluginManager/scss/style.scss
+++ b/src/Powercord/plugins/pc-pluginManager/scss/style.scss
@@ -3,15 +3,19 @@
 
 .powercord-plugins {
   &-wip {
-    position: absolute;
-    top: 0;
+    top: -5px;
     left: 0;
     right: 0;
     font-size: 18px;
     padding: 10px;
     text-align: center;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    position: sticky;
+    margin-bottom: 20px;
+    width: 100%;
+    border-radius: 5px;
+    background-color: #f44336;
+    color: white;
+    z-index: 999;
   }
 
   &-header {


### PR DESCRIPTION
Fixed readability-issues, and make the warning a lot more obvious (scrolls with content now).

![image](https://user-images.githubusercontent.com/29519722/56724842-0cb6e900-674c-11e9-9d79-3d01e7cbcc67.png)
![image](https://user-images.githubusercontent.com/29519722/56724855-12acca00-674c-11e9-8a30-c17e4088ed7b.png)
