### PR TITLE
Utilize seperators and customizability for slider

### DIFF
--- a/src/Powercord/plugins/pc-clickableEdits/Settings.jsx
+++ b/src/Powercord/plugins/pc-clickableEdits/Settings.jsx
@@ -2,52 +2,33 @@ const { React } = require('powercord/webpack');
 const { SwitchItem } = require('powercord/components/settings');
 
 module.exports = class Settings extends React.Component {
-  constructor (props) {
-    super(props);
-
-    const get = props.settings.get.bind(props.settings);
-
-    this.state = {
-      dualControlEdits: get('dualControlEdits', false),
-      rightClickEdits: get('rightClickEdits', false),
-      clearContent: get('clearContent', false),
-      useShiftKey: get('useShiftKey', false)
-    };
-  }
-
   render () {
-    const { dualControlEdits, rightClickEdits, clearContent, useShiftKey } = this.state;
+    const { getSetting, toggleSetting } = this.props;
 
     return (
       <div>
         <SwitchItem
           note={'Provides the ability to use the ‘shift’ key and primary button to perform cleared message edits while also ' +
             'being able to double-click the primary button to edit messages normally (without the removable of content).'}
-          value={dualControlEdits}
-          onChange={() => {
-            this._set('dualControlEdits');
-          }}
+          value={getSetting('dualControlEdits', false)}
+          onChange={() => toggleSetting('dualControlEdits')}
         >
           Enable Dual Control Edits
         </SwitchItem>
 
         <SwitchItem
           note={'Sets the right mouse button (RMB) as the primary control for performing message edits.'}
-          value={rightClickEdits}
-          onChange={() => {
-            this._set('rightClickEdits');
-          }}
+          value={getSetting('rightClickEdits', false)}
+          onChange={() => toggleSetting('rightClickEdits')}
         >
           Swap Primary Button
         </SwitchItem>
 
         <SwitchItem
           note={'Removes the message content upon editing (not sure why you\'d have this enabled, but it\'s there if you ever need it).'}
-          disabled={dualControlEdits}
-          value={clearContent}
-          onChange={() => {
-            this._set('clearContent');
-          }}
+          disabled={getSetting('dualControlEdits', false)}
+          value={getSetting('clearContent', false)}
+          onChange={() => toggleSetting('clearContent')}
         >
           Enable Clear Content
         </SwitchItem>
@@ -55,26 +36,15 @@ module.exports = class Settings extends React.Component {
         <SwitchItem
           note={
             <span>Makes it so that the ‘shift’ key must be held down before clicking the left or right mouse button to initiate an edit.
-              <b style={{ color: 'rgb(240, 71, 71)' }}>HeAdS uP:</b> Having this setting disabled will result in double-click edits by default. Don't say I didn't tell you.</span>
+              <b style={{ color: 'rgb(240, 71, 71)' }}>HEADS UP:</b> Having this setting disabled will result in double-click edits by default. Don't say I didn't tell you.</span>
           }
-          disabled={dualControlEdits}
-          value={useShiftKey}
-          onChange={() => {
-            this._set('useShiftKey');
-          }}
+          disabled={getSetting('dualControlEdits', false)}
+          value={getSetting('useShiftKey', false)}
+          onChange={() => toggleSetting('useShiftKey')}
         >
           Use Shift Key
         </SwitchItem>
       </div>
     );
-  }
-
-  _set (key, value = !this.state[key], defaultValue) {
-    if (!value && defaultValue) {
-      value = defaultValue;
-    }
-
-    this.props.settings.set(key, value);
-    this.setState({ [key]: value });
   }
 };

--- a/src/Powercord/plugins/pc-clickableEdits/index.js
+++ b/src/Powercord/plugins/pc-clickableEdits/index.js
@@ -1,6 +1,6 @@
 const { Plugin } = require('powercord/entities');
 const { getOwnerInstance, waitFor } = require('powercord/util');
-const { contextMenu, getModule, React } = require('powercord/webpack');
+const { contextMenu, getModule } = require('powercord/webpack');
 const { inject, uninject } = require('powercord/injector');
 
 const Settings = require('./Settings');
@@ -8,11 +8,7 @@ const Settings = require('./Settings');
 class ClickableEdits extends Plugin {
   startPlugin () {
     this.patchMessageContent();
-    this.registerSettings('pc-clickableEdits', 'Clickable Edits', () =>
-      React.createElement(Settings, {
-        settings: this.settings
-      })
-    );
+    this.registerSettings('pc-clickableEdits', 'Clickable Edits', Settings);
   }
 
   pluginWillUnload () {

--- a/src/Powercord/plugins/pc-clickableEdits/manifest.json
+++ b/src/Powercord/plugins/pc-clickableEdits/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clickable Message Edits",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A quick and easy solution for editing messages faster.",
   "author": "Harley#1051",
   "license": "MIT"

--- a/src/fake_node_modules/powercord/components/ContextMenu/Checkbox.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Checkbox.jsx
@@ -17,7 +17,7 @@ module.exports = class CheckboxItem extends React.PureComponent {
   }
 
   render () {
-    return (
+    const checkbox = (
       <div
         className='pc-item pc-itemToggle item-1Yvehc itemToggle-S7XGOQ'
         role='button'
@@ -35,5 +35,15 @@ module.exports = class CheckboxItem extends React.PureComponent {
         </div>
       </div>
     );
+
+    if (this.props.seperate) {
+      return (
+        <div className='pc-itemGroup itemGroup-1tL0uz seperated'>
+          {checkbox}
+        </div>
+      );
+    }
+
+    return checkbox;
   }
 };

--- a/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
@@ -13,23 +13,34 @@ module.exports = class SliderItem extends React.PureComponent {
   }
 
   render () {
-    return (
+    const slider = (
       <div className='pc-item pc-itemSlider item-1Yvehc itemSlider-FZeYw0'>
         <div className='pc-label label-JWQiNe'>{this.props.name}</div>
 
         <Slider
-          mini={true}
-          handleSize={16}
+          mini={this.props.mini}
+          handleSize={this.props.handleSize}
           className='pc-slider slider-3BOep7'
           fillStyles={this.props.color ? { backgroundColor: this.props.color } : {}}
           defaultValue={this.props.defaultValue}
-          minValue={0}
-          maxValue={100}
-          disabled={false}
-          stickToMarkers={false}
+          minValue={this.props.minValue}
+          maxValue={this.props.maxValue}
+          disabled={this.props.disabled}
+          stickToMarkers={this.props.stickToMarkers}
           onValueChange={this.props.onValueChange}
+          onValueRender={this.props.onValueRender}
         />
       </div>
     );
+
+    if (this.props.seperate) {
+      return (
+        <div className='pc-itemGroup itemGroup-1tL0uz seperated'>
+          {slider}
+        </div>
+      );
+    }
+
+    return slider;
   }
 };


### PR DESCRIPTION
* Allow `Slider` and `Checkbox` component to make work of seperators
* Introduce support for custom slider options (e.g. mini, handleSize, minValue, maxValue etc.) - need this in preparation for my up and coming Powercord context menu... Coming Soon™ c:
* And non-related but still worth mentioning: move the settings of `pc-clickableEdits` to flux store and bump version number from '0.1.3' to '0.1.4'