### PR TITLE
GitHub Organization Changes

### DIFF
--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -184,7 +184,7 @@ module.exports = class PluginManager {
 
   // Install
   async install (pluginID) {
-    await exec(`git clone https://github.com/powercord-org/${pluginID}`, this.pluginDir);
+    await exec(`git clone https://github.com/powercord-community/${pluginID}`, this.pluginDir);
     this.mount(pluginID);
   }
 

--- a/src/Powercord/managers/styles/index.js
+++ b/src/Powercord/managers/styles/index.js
@@ -94,7 +94,7 @@ module.exports = class StyleManager {
   /*
    * @todo
    * async install (pluginID) {
-   *   await exec(`git clone https://github.com/powercord-org/${pluginID}`, this.pluginDir);
+   *   await exec(`git clone https://github.com/powercord-community/${pluginID}`, this.pluginDir);
    *   this.mount(pluginID);
    * }
    *


### PR DESCRIPTION
The commit basically changes `powercord-org` to `powercord-community` when installing plugins and/or themes from git's cli component.