### PR TITLE
Better Cursor for Guilds Plugin (beside Guild itself)

### DIFF
--- a/src/Powercord/plugins/pc-guilds/style.scss
+++ b/src/Powercord/plugins/pc-guilds/style.scss
@@ -73,7 +73,7 @@
   }
 }
 
-[data-react-beautiful-dnd-drag-handle="4"]{
+.pc-guild {
   cursor: pointer!important;
 }
 

--- a/src/Powercord/plugins/pc-guilds/style.scss
+++ b/src/Powercord/plugins/pc-guilds/style.scss
@@ -73,6 +73,10 @@
   }
 }
 
+[data-react-beautiful-dnd-drag-handle="4"]{
+  cursor: pointer!important;
+}
+
 .powercord-create-folder {
   &-container {
     display: flex;

--- a/src/Powercord/plugins/pc-pluginManager/scss/style.scss
+++ b/src/Powercord/plugins/pc-pluginManager/scss/style.scss
@@ -3,15 +3,19 @@
 
 .powercord-plugins {
   &-wip {
-    position: absolute;
-    top: 0;
+    top: -5px;
     left: 0;
     right: 0;
     font-size: 18px;
     padding: 10px;
     text-align: center;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    position: sticky;
+    margin-bottom: 20px;
+    width: 100%;
+    border-radius: 5px;
+    background-color: #f44336;
+    color: white;
+    z-index: 999;
   }
 
   &-header {


### PR DESCRIPTION
Very small change and don't know if intended: 

When hovered beside the guild itself and onto the span (or even next to that), cursor grab appears. I don't know if this is intended but it sure looks odd. 
![image](https://user-images.githubusercontent.com/29519722/56800023-5d951300-681a-11e9-8899-e7998cc85cce.png)
vs (fixed with cursor: pointer)
![image](https://user-images.githubusercontent.com/29519722/56800087-84ebe000-681a-11e9-89b1-1a5ca514fcc0.png)
