### PR TITLE
Fix context menu slider from showing up too large

### DIFF
--- a/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
@@ -18,7 +18,7 @@ module.exports = class SliderItem extends React.PureComponent {
         <div className='pc-label label-JWQiNe'>{this.props.name}</div>
 
         <Slider
-          mini={this.props.mini || true}
+          mini={this.props.mini !== undefined ? this.props.mini : true}
           handleSize={this.props.handleSize}
           className='pc-slider slider-3BOep7'
           fillStyles={this.props.color ? { backgroundColor: this.props.color } : {}}

--- a/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
@@ -18,7 +18,7 @@ module.exports = class SliderItem extends React.PureComponent {
         <div className='pc-label label-JWQiNe'>{this.props.name}</div>
 
         <Slider
-          mini={this.props.mini}
+          mini={this.props.mini || true}
           handleSize={this.props.handleSize}
           className='pc-slider slider-3BOep7'
           fillStyles={this.props.color ? { backgroundColor: this.props.color } : {}}


### PR DESCRIPTION
Resolves the volume control slider found under the Spotify modal context menu from displaying in a larger size.