### PR TITLE
Introduce some bug fixes and extra additions

### DIFF
--- a/src/Powercord/plugins/pc-commands/monkeypatchTyping.js
+++ b/src/Powercord/plugins/pc-commands/monkeypatchTyping.js
@@ -1,14 +1,14 @@
 const { typing } = require('powercord/webpack');
 
 module.exports = async function monkeypatchTyping () {
-  typing.sendTyping = (
-    _sendTyping => (id) =>
+  typing.startTyping = (
+    _startTyping => (id) =>
       setImmediate(() => {
         if (this.instance && this.instance.props.value.startsWith(powercord.api.commands.prefix)) {
           return;
         }
 
-        _sendTyping(id);
+        _startTyping(id);
       })
-  )(this.oldSendTyping = typing.sendTyping);
+  )(this.oldStartTyping = typing.startTyping);
 };

--- a/src/Powercord/plugins/pc-pluginManager/components/Installed.jsx
+++ b/src/Powercord/plugins/pc-pluginManager/components/Installed.jsx
@@ -16,20 +16,20 @@ module.exports = class Installed extends React.Component {
       search: ''
     };
 
-    this.openFolder = function(dir) {
+    this.openFolder = (dir) => {
       const cmds = {
-        "win32": "explorer",
-        "darwin": "open",
-        "linux": "xdg-open"
-      }
-      spawn(cmds[process.platform], [dir]);
+        win32: 'explorer',
+        darwin: 'open',
+        linux: 'xdg-open'
+      };
+      spawn(cmds[process.platform], [ dir ]);
     }
 
-    this.openPluginsFolder = function() {
+    this.openPluginsFolder = () => {
       this.openFolder(resolve(__dirname, '..', '..'));
     }
 
-    this.openThemesFolder = function() {
+    this.openThemesFolder = () => {
       this.openFolder(resolve(__dirname, '..', '..', '..', 'themes'));
     }
   }

--- a/src/Powercord/plugins/pc-pluginManager/scss/style.scss
+++ b/src/Powercord/plugins/pc-pluginManager/scss/style.scss
@@ -3,7 +3,7 @@
 
 .powercord-plugins {
   &-wip {
-    top: -5px;
+    top: 0;
     left: 0;
     right: 0;
     font-size: 18px;

--- a/src/Powercord/plugins/pc-pluginManager/scss/style.scss
+++ b/src/Powercord/plugins/pc-pluginManager/scss/style.scss
@@ -3,7 +3,7 @@
 
 .powercord-plugins {
   &-wip {
-    top: 0;
+    top: -1.4px;
     left: 0;
     right: 0;
     font-size: 18px;

--- a/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
@@ -2,7 +2,7 @@ const { React, contextMenu } = require('powercord/webpack');
 const { getOwnerInstance, waitFor } = require('powercord/util');
 
 let appOwnerInstance;
-waitFor('.app')
+waitFor('.pc-app > .pc-app')
   .then(app => (
     appOwnerInstance = getOwnerInstance(app)
   ));
@@ -10,7 +10,7 @@ waitFor('.app')
 module.exports = class ButtonItem extends React.PureComponent {
   onClick () {
     if (this.props.disabled) {
-      appOwnerInstance.shake();
+      appOwnerInstance.shake(600, 5);
     } else {
       contextMenu.closeContextMenu();
       this.props.onClick();

--- a/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Slider.jsx
@@ -20,13 +20,16 @@ module.exports = class SliderItem extends React.PureComponent {
         <Slider
           mini={this.props.mini !== undefined ? this.props.mini : true}
           handleSize={this.props.handleSize}
-          className='pc-slider slider-3BOep7'
+          className={`pc-slider slider-3BOep7 ${this.props.className || ''}`}
           fillStyles={this.props.color ? { backgroundColor: this.props.color } : {}}
           defaultValue={this.props.defaultValue}
           minValue={this.props.minValue}
           maxValue={this.props.maxValue}
           disabled={this.props.disabled}
+          equidistant={this.props.equidistant}
           stickToMarkers={this.props.stickToMarkers}
+          markers={this.props.markers}
+          onMarkerRender={this.props.onMarkerRender}
           onValueChange={this.props.onValueChange}
           onValueRender={this.props.onValueRender}
         />

--- a/src/fake_node_modules/powercord/webpack/modules.json
+++ b/src/fake_node_modules/powercord/webpack/modules.json
@@ -5,7 +5,7 @@
     "deleteMessage"
   ],
   "typing": [
-    "sendTyping"
+    "startTyping"
   ],
   "http": [
     "getAPIBaseURL",


### PR DESCRIPTION
* Replace all traces of the `sendTyping` method with `startTyping` as it is now deprecated
* Set the `top` declaration for the plugin warning found under 'pc-pluginManager' to a value of '-1.4px' - this prevents the ghost pill from cutting off the screen.
* Make the recently implemented plugin/theme folder opener ESLint-compliant (`Installed.jsx`).
* And finally, context menu buttons now react when disabled by shaking the screen (this has been broken for some time now...). I've also made changes to sliders by giving plug-in developers the freedom to customize/use markers and class names.