### PR TITLE
Utilize images/icons for submenus and buttons

### DIFF
--- a/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
@@ -20,16 +20,21 @@ module.exports = class ButtonItem extends React.PureComponent {
   render () {
     const button = (
       <div
-        className={`pc-item item-1Yvehc ${this.props.disabled ? 'disabled' : ''}`}
+        className={
+          `pc-item item-1Yvehc ${this.props.image ? 'pc-itemImage itemImage-htIz_v' : ''}
+          ${this.props.disabled ? 'disabled' : ''}`
+        }
         role='button'
         onClick={this.onClick.bind(this)}
       >
         <span style={{ color: this.props.highlight }}>
           {this.props.name}
         </span>
-        <div className='pc-hint hint-22uc-R'>
-          {this.props.hint}
-        </div>
+        {this.props.image
+          ? this.getButtonImage()
+          : <div className='pc-hint hint-22uc-R'>
+            {this.props.hint}
+          </div>}
       </div>
     );
 
@@ -42,5 +47,17 @@ module.exports = class ButtonItem extends React.PureComponent {
     }
 
     return button;
+  }
+
+  getButtonImage () {
+    return (
+      this.props.image.startsWith('fa-')
+        ? <div style={{ cursor: 'pointer!important' }}
+          class={`${this.props.image.endsWith('-alt')
+            ? 'far'
+            : 'fas'}
+            ${this.props.image.replace('-alt', '')} fa-fw`} />
+        : <img src={this.props.image} />
+    );
   }
 };

--- a/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
@@ -57,7 +57,7 @@ module.exports = class ButtonItem extends React.PureComponent {
             ? 'far'
             : 'fas'}
             ${this.props.image.replace('-alt', '')} fa-fw`} />
-        : <img src={this.props.image} />
+        : <img alt src={this.props.image} />
     );
   }
 };

--- a/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
@@ -95,7 +95,7 @@ class SubmenuItem extends React.Component {
           ? 'far'
           : 'fas'}
           ${this.props.image.replace('-alt', '')} fa-fw`} />
-        : <img style={{ marginRight: '10px' }} src={this.props.image} />
+        : <img alt style={{ marginRight: '10px' }} src={this.props.image} />
     );
   }
 

--- a/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
@@ -56,7 +56,8 @@ class SubmenuItem extends React.Component {
   render () {
     const submenu = (
       <div
-        className='pc-item pc-itemSubMenu item-1Yvehc itemSubMenu-1vN_Yn'
+        className={`pc-item pc-itemSubMenu item-1Yvehc itemSubMenu-1vN_Yn
+          ${this.props.image ? 'pc-itemImage itemImage-htIz_v' : ''}`}
         onClick={this.onClick.bind(this)}
         onMouseEnter={this.onEnter.bind(this)}
         onMouseLeave={this.onLeave.bind(this)}
@@ -67,9 +68,11 @@ class SubmenuItem extends React.Component {
             ? this.getSubContextMenu()
             : null
         }
-        <div className='pc-hint hint-22uc-R'>
-          {this.props.hint}
-        </div>
+        {this.props.image
+          ? this.getSubmenuImage()
+          : <div className='pc-hint hint-22uc-R'>
+            {this.props.hint}
+          </div>}
       </div>
     );
 
@@ -82,6 +85,18 @@ class SubmenuItem extends React.Component {
     }
 
     return submenu;
+  }
+
+  getSubmenuImage () {
+    return (
+      this.props.image.startsWith('fa-')
+        ? <div style={{ cursor: 'pointer!important',
+          marginRight: '10px' }} class={`${this.props.image.endsWith('-alt')
+          ? 'far'
+          : 'fas'}
+          ${this.props.image.replace('-alt', '')} fa-fw`} />
+        : <img style={{ marginRight: '10px' }} src={this.props.image} />
+    );
   }
 
   getSubContextMenu () {


### PR DESCRIPTION
- Introduces support for web images and FontAwesome icons shown in context menus, providing more customizability and freedom towards some of the plug-in developers that currently make use of context menus (totally not speaking for myself here...).

  Here's a screenshot of it in action:

  ![DiscordCanary_yOMc8VstHi](https://user-images.githubusercontent.com/12791846/58749942-5de69500-84cf-11e9-84bf-a78003a870de.png)
