### PR TITLE
Add icons to Spotify Modal context menu

### DIFF
--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -303,7 +303,8 @@ module.exports = class Modal extends React.Component {
       this.state,
       this.onButtonClick,
       powercord.account && powercord.account.spotify,
-      !this.props.showAdvanced
+      !this.props.showAdvanced,
+      !this.props.settings.showContextIcons
     );
     contextMenu.openContextMenu(e, () =>
       React.createElement(ContextMenu, {

--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -304,7 +304,7 @@ module.exports = class Modal extends React.Component {
       this.onButtonClick,
       powercord.account && powercord.account.spotify,
       !this.props.showAdvanced,
-      !this.props.settings.showContextIcons
+      !this.props.getSetting('showContextIcons', true)
     );
     contextMenu.openContextMenu(e, () =>
       React.createElement(ContextMenu, {

--- a/src/Powercord/plugins/pc-spotify/Modal/contextMenuGroups.js
+++ b/src/Powercord/plugins/pc-spotify/Modal/contextMenuGroups.js
@@ -3,7 +3,27 @@ const { messages, channels } = require('powercord/webpack');
 const { formatTime } = require('powercord/util');
 const SpotifyPlayer = require('../SpotifyPlayer');
 
-module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
+function getDeviceIcon (device) {
+  const deviceIcons = {
+    Computer: 'fa-desktop',
+    Tablet: 'fa-tablet-alt',
+    Smartphone: 'fa-mobile-alt',
+    Speaker: 'fa-volume-up',
+    TV: 'fa-tv',
+    AVR: 'fa-digital-tachograph',
+    STB: 'fa-hdd',
+    AudioDongle: 'fa-usb-brand',
+    GameConsole: 'fa-gamepad',
+    CastAudio: 'fa-bluetooth-b-brand',
+    CastVideo: 'fa-video',
+    Car: 'fa-car',
+    Unknown: 'fa-question-circle'
+  };
+
+  return deviceIcons[device];
+}
+
+module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden, hasIconsHidden) => [
   [ {
     type: 'submenu',
     name: 'Devices',
@@ -16,7 +36,8 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
           return {
             type: 'button',
             name: device.name,
-            hint: device.type,
+            image: hasIconsHidden ? '' : getDeviceIcon(device.type),
+            hint: hasIconsHidden ? device.type : '',
             highlight: isActiveDevice && '#1ed860',
             disabled: isActiveDevice,
             seperate: isActiveDevice,
@@ -84,6 +105,7 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
       getItems: () => [ {
         type: 'submenu',
         name: 'Repeat Modes',
+        image: hasIconsHidden ? '' : 'fa-sync',
         getItems: () => [ {
           name: 'On',
           stateName: 'context'
@@ -121,11 +143,13 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
     ? [ {
       type: 'button',
       name: 'Add to Library',
+      image: hasIconsHidden ? '' : 'fa-plus-circle',
       onClick: () =>
         SpotifyPlayer.addSong(state.currentItem.id)
     }, {
       type: 'button',
       name: 'Save to Playlist',
+      image: hasIconsHidden ? '' : 'fa-save',
       onClick: () =>
         powercord.pluginManager.get('pc-spotify').openPlaylistModal(state.currentItem.id)
       } ]
@@ -134,11 +158,13 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
   [ {
     type: 'button',
     name: 'Open in Spotify',
+    image: hasIconsHidden ? '' : 'fa-external-link-alt',
     onClick: () =>
       shell.openExternal(state.currentItem.uri)
   }, {
     type: 'button',
     name: 'Send URL to Channel',
+    image: hasIconsHidden ? '' : 'fa-share-square',
     onClick: () =>
       messages.sendMessage(
         channels.getChannelId(),
@@ -147,6 +173,7 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden) => [
   }, {
     type: 'button',
     name: 'Copy URL',
+    image: hasIconsHidden ? '' : 'fa-copy',
     onClick: () =>
       clipboard.writeText(state.currentItem.url)
   } ]

--- a/src/Powercord/plugins/pc-spotify/Settings.jsx
+++ b/src/Powercord/plugins/pc-spotify/Settings.jsx
@@ -21,5 +21,13 @@ module.exports = ({ getSetting, toggleSetting, patch }) => (
     >
       No auto pause
     </SwitchItem>
+
+    <SwitchItem
+      note={'Adds icons next to first glace buttons and replaces hints found under the \'Devices\' sub-menu with corresponding icons based on the device(s) in-use.'}
+      value={getSetting('showContextIcons', false)}
+      onChange={() => toggleSetting('showContextIcons')}
+    >
+      Show context menu icons
+    </SwitchItem>
   </div>
 );

--- a/src/Powercord/plugins/pc-spotify/Settings.jsx
+++ b/src/Powercord/plugins/pc-spotify/Settings.jsx
@@ -24,7 +24,7 @@ module.exports = ({ getSetting, toggleSetting, patch }) => (
 
     <SwitchItem
       note={'Adds icons next to first glace buttons and replaces hints found under the \'Devices\' sub-menu with corresponding icons based on the device(s) in-use.'}
-      value={getSetting('showContextIcons', false)}
+      value={getSetting('showContextIcons', true)}
       onChange={() => toggleSetting('showContextIcons')}
     >
       Show context menu icons

--- a/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Button.jsx
@@ -53,11 +53,14 @@ module.exports = class ButtonItem extends React.PureComponent {
     return (
       this.props.image.startsWith('fa-')
         ? <div style={{ cursor: 'pointer!important' }}
-          class={`${this.props.image.endsWith('-alt')
+          class={`${this.props.image.endsWith('-regular')
             ? 'far'
-            : 'fas'}
-            ${this.props.image.replace('-alt', '')} fa-fw`} />
-        : <img alt src={this.props.image} />
+            : this.props.image.endsWith('-brand')
+              ? 'fab'
+              : 'fas'}
+            ${this.props.image.replace(/-regular|-brand/gi, '')} fa-fw`} />
+        : <img alt className={this.props.className || ''}
+          src={this.props.image} />
     );
   }
 };

--- a/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
+++ b/src/fake_node_modules/powercord/components/ContextMenu/Submenu.jsx
@@ -91,11 +91,14 @@ class SubmenuItem extends React.Component {
     return (
       this.props.image.startsWith('fa-')
         ? <div style={{ cursor: 'pointer!important',
-          marginRight: '10px' }} class={`${this.props.image.endsWith('-alt')
+          marginRight: '10px' }} class={`${this.props.image.endsWith('-regular')
           ? 'far'
-          : 'fas'}
-          ${this.props.image.replace('-alt', '')} fa-fw`} />
-        : <img alt style={{ marginRight: '10px' }} src={this.props.image} />
+          : this.props.image.endsWith('-brand')
+            ? 'fab'
+            : 'fas'}
+          ${this.props.image.replace(/-regular|-brand/gi, '')} fa-fw`} />
+        : <img alt className={this.props.className || ''}
+          style={{ marginRight: '10px' }} src={this.props.image} />
     );
   }
 


### PR DESCRIPTION
- Make use of FontAwesome icons for first glace buttons (E.g. Open in Spotify, Send URL to Channel, Copy ID etc.) and replace hints found under the 'Devices' sub-menu with corresponding icons - the user will be able to toggle these icons on/off via the new setting 'Show context menu icons'
  
  Example:

  ![iUBhxnjEFO](https://user-images.githubusercontent.com/12791846/58758302-f4ad6300-855c-11e9-8335-6f4ac303de35.png)

- Add support for regular and brand FontAwesome icons, and allow developers to define a class name for buttons and sub-menus in order to help assist with image customizability