### PR TITLE
Add a say command

### DIFF
--- a/src/Powercord/plugins/pc-commands/commands/say.js
+++ b/src/Powercord/plugins/pc-commands/commands/say.js
@@ -1,0 +1,9 @@
+module.exports = {
+  command: 'say',
+  description: 'Sends the specified arguments.',
+  usage: '{c} [ ...arguments ]',
+  func: (args) => ({
+    send: true,
+    result: args.join(' ')
+  })
+};


### PR DESCRIPTION
Add a say command so people can use bot commands with the same name as local Powercord commands

e.g. if a person were to have their powercord prefix set to `.` they couldn't use the `help` command from bots with the same prefix. This command simply works around that by making a powercord command in the pc-commands plugin that just sends the message you provide.
There's probably a better way to do this but this is the simplest.
