### PR TITLE
Various fixes and enhancements; fixes #64, closes #117, closes #177

### DIFF
--- a/src/Powercord/plugins/pc-announcements/Notice.jsx
+++ b/src/Powercord/plugins/pc-announcements/Notice.jsx
@@ -2,22 +2,22 @@ const { React, getModule, getModuleByDisplayName } = require('powercord/webpack'
 const { AsyncComponent } = require('powercord/components');
 
 const Clickable = AsyncComponent.from(getModuleByDisplayName('Clickable'));
-let classesStore = null;
-
 const Notice = class Notice extends React.Component {
   constructor () {
     super();
 
-    this.state = classesStore || {
-      types: [],
+    this.classesStore = null;
+    this.state = this.classesStore || {
+      types: {},
       button: '',
       dismiss: ''
     };
   }
 
   async componentDidMount () {
-    if (!classesStore) {
-      const classes = await getModule([ 'noticeBrand' ]);
+    if (!this.classesStore) {
+      const classes = (await getModule([ 'noticeBrand' ]));
+
       this.setState({
         types: {
           BLURPLE: classes.noticeBrand,
@@ -35,7 +35,8 @@ const Notice = class Notice extends React.Component {
         button: classes.button,
         dismiss: classes.dismiss
       });
-      classesStore = this.state;
+
+      this.classesStore = this.state;
     }
   }
 
@@ -63,7 +64,8 @@ Notice.TYPES = {
   SPOTIFY: 'SPOTIFY',
   PURPLE: 'PURPLE',
   GREEN: 'GREEN',
-  SURVEY: 'SURVEY' // noticeInfo's (Notice.TYPES.BLUE) evil twin -- hovering over the CTA button greets you with some gloomy black text instead of the traditional white.
+  SURVEY: 'SURVEY' /* noticeInfo's (Notice.TYPES.BLUE) evil twin -- hovering over the CTA button greets
+    you with some gloomy black text instead of the traditional white. */
 };
 
 module.exports = Notice;

--- a/src/Powercord/plugins/pc-announcements/manifest.json
+++ b/src/Powercord/plugins/pc-announcements/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Announcements",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Broadcast announcements from Powercord API or plugins",
   "author": "Powercord Team",
   "license": "MIT",

--- a/src/Powercord/plugins/pc-clickableEdits/index.js
+++ b/src/Powercord/plugins/pc-clickableEdits/index.js
@@ -1,24 +1,37 @@
 const { Plugin } = require('powercord/entities');
-const { getOwnerInstance, waitFor } = require('powercord/util');
+const { forceUpdateElement, getOwnerInstance, waitFor } = require('powercord/util');
 const { contextMenu, getModule } = require('powercord/webpack');
 const { inject, uninject } = require('powercord/injector');
 
 const Settings = require('./Settings');
 
 class ClickableEdits extends Plugin {
-  startPlugin () {
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      messageQuery: ''
+    };
+  }
+
+  async startPlugin () {
+    this.state.messageClasses = {
+      textAreaEdit: (await getModule([ 'textAreaEdit' ])).textAreaEdit
+    };
+
     this.patchMessageContent();
     this.registerSettings('pc-clickableEdits', 'Clickable Edits', Settings);
   }
 
   pluginWillUnload () {
     uninject('pc-clickableEdits-MessageContent');
+    forceUpdateElement(this.state.messageQuery, true);
   }
 
   async patchMessageContent () {
     const _this = this;
 
-    const messageClasses = await getModule([ 'messageCompact', 'messageCozy' ]);
+    const messageClasses = (await getModule([ 'messageCompact', 'messageCozy' ]));
     const messageQuery = `.${messageClasses.message.replace(/ /g, '.')}`;
 
     const instance = getOwnerInstance(await waitFor(messageQuery));
@@ -36,7 +49,9 @@ class ClickableEdits extends Plugin {
 
     inject('pc-clickableEdits-MessageContent', instance.__proto__, 'render', renderMessage);
 
-    this.forceUpdate(messageQuery);
+    forceUpdateElement(messageQuery, true);
+
+    this.state.messageQuery = messageQuery;
   }
 
   handleMessageEdit (channelId, messageId, content) {
@@ -58,36 +73,23 @@ class ClickableEdits extends Plugin {
           : false);
 
       if (this.settings.get('dualControlEdits', false) ? dualControl : this.settings.get('useShiftKey', false) ? shiftKey : doubleClick) {
-        if (e.target.className && e.target.className.includes('pc-markup')) {
-          const editMessage = (await getModule([ 'editMessage' ])).startEditMessage;
+        if (e.target.className && (e.target.className.includes('markup') || e.target.className.includes('container'))) {
+          const { textAreaEdit } = this.state.messageClasses;
+          const { startEditMessage: editMessage } = (await getModule([ 'editMessage' ]));
           editMessage(args[0], args[1], args[2]);
 
           setTimeout(() => {
-            const elem = document.getElementsByClassName('pc-textAreaEdit')[0];
+            const elem = document.getElementsByClassName(textAreaEdit.replace(/ /g, '.'))[0];
             if (elem) {
               elem.focus();
               elem.setSelectionRange(elem.value.length, elem.value.length);
             }
+
             contextMenu.closeContextMenu();
           }, 100);
         }
       }
     };
-  }
-
-  /*
-   * DISCLAIMER: the following method was taken from .intrnl#6380's 'blackboxTags'
-   * plug-in - this section of code does not belong to me.
-   */
-  forceUpdate (query) {
-    const elements = [
-      ...document.querySelectorAll(query)
-    ];
-
-    for (const elem of elements) {
-      const instance = getOwnerInstance(elem);
-      instance.forceUpdate();
-    }
   }
 }
 

--- a/src/Powercord/plugins/pc-clickableEdits/manifest.json
+++ b/src/Powercord/plugins/pc-clickableEdits/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clickable Message Edits",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "A quick and easy solution for editing messages faster.",
   "author": "Harley#1051",
   "license": "MIT"

--- a/src/Powercord/plugins/pc-emojiUtility/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/components/Settings.jsx
@@ -2,13 +2,13 @@ const { existsSync, lstatSync } = require('fs');
 const { React, getModule } = require('powercord/webpack');
 const { SwitchItem, TextInput, Category } = require('powercord/components/settings');
 
-let getGuild, getSortedGuilds;
+let getGuild, getFlattenedGuilds;
 
 module.exports = class EmojiUtilitySettings extends React.Component {
   constructor (props) {
     super(props);
 
-    if (getGuild && getSortedGuilds) {
+    if (getGuild && getFlattenedGuilds) {
       this._setState(false);
     }
   }
@@ -30,16 +30,16 @@ module.exports = class EmojiUtilitySettings extends React.Component {
   }
 
   async componentDidMount () {
-    if (!(getGuild && getSortedGuilds)) {
+    if (!(getGuild && getFlattenedGuilds)) {
       ({ getGuild } = await getModule([ 'getGuild' ]));
-      ({ getSortedGuilds } = await getModule([ 'getSortedGuilds' ]));
+      ({ getFlattenedGuilds } = await getModule([ 'getFlattenedGuilds' ]));
 
       this._setState();
     }
   }
 
   render () {
-    if (!(getGuild && getSortedGuilds)) {
+    if (!(getGuild && getFlattenedGuilds)) {
       return null;
     }
 
@@ -133,7 +133,7 @@ module.exports = class EmojiUtilitySettings extends React.Component {
           opened={this.state.categoryOpened}
           onChange={() => this.setState({ categoryOpened: !this.state.categoryOpened })}
         >
-          {getSortedGuilds().map(g => g.guilds[0]).map(g => <SwitchItem
+          {getFlattenedGuilds().map(g => <SwitchItem
             value={this.props.getSetting('hiddenGuilds', []).includes(g.id)}
             onChange={() => this._handleGuildToggle(g.id)}
           >

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -52,7 +52,7 @@ module.exports = class EmojiUtility extends Plugin {
 
     await this.import('getGuild');
     await this.import('getGuilds');
-    await this.import('getSortedGuilds');
+    await this.import('getFlattenedGuilds');
     await this.import('uploadEmoji');
     await this.import('getChannel');
     await this.import('getGuildPermissions');
@@ -62,6 +62,7 @@ module.exports = class EmojiUtility extends Plugin {
     await this.import('receiveMessage');
     await this.import('getSelectedChannelState');
     await this.import('getChannelId');
+    await this.import('queryEmojiResults');
   }
 
   getEmojiRegex () {
@@ -210,6 +211,10 @@ module.exports = class EmojiUtility extends Plugin {
     return Object.values(this.emojiStore.getGuilds()).flatMap(g => g.emojis).find(e => e.id === id);
   }
 
+  getHiddenGuilds () {
+    return this.settings.get('hiddenGuilds', []);
+  }
+
   getMaxEmojiSlots (guildId) {
     return this.getGuild(guildId).getMaxEmojiSlots();
   }
@@ -274,7 +279,7 @@ module.exports = class EmojiUtility extends Plugin {
 
       const getCloneableGuilds = () => {
         const items = [];
-        const clonableGuilds = Object.values(this.getSortedGuilds()).map(g => g.guilds[0]).filter(guild => this.hasPermission(guild.id, Permissions.MANAGE_EMOJIS));
+        const clonableGuilds = Object.values(this.getFlattenedGuilds()).filter(guild => this.hasPermission(guild.id, Permissions.MANAGE_EMOJIS));
 
         for (const guild of clonableGuilds) {
           items.push({
@@ -414,7 +419,7 @@ module.exports = class EmojiUtility extends Plugin {
 
       const getCreateableGuilds = () => {
         const items = [];
-        const createableGuilds = Object.values(this.getSortedGuilds()).map(g => g.guilds[0]).filter(guild => this.hasPermission(guild.id, Permissions.MANAGE_EMOJIS));
+        const createableGuilds = Object.values(this.getFlattenedGuilds()).filter(guild => this.hasPermission(guild.id, Permissions.MANAGE_EMOJIS));
 
         for (const guild of createableGuilds) {
           items.push({
@@ -574,22 +579,18 @@ module.exports = class EmojiUtility extends Plugin {
      * });
      */
 
-    const Autocomplete = await getModuleByDisplayName('Autocomplete');
-    inject('pc-emojiUtility-hideEmojisComplete', Autocomplete.prototype, 'render', (args, res) => {
-      if (res) {
-        const hiddenGuilds = _this.settings.get('hiddenGuilds', []);
+    const ChannelTextArea = await getModuleByDisplayName('ChannelTextArea');
+    inject('pc-emojiUtility-hideEmojisComplete', ChannelTextArea.prototype, 'componentDidUpdate', (args) => {
+      const { autocompleteOptions, channel } = args.find(key => key && key.autocompleteOptions);
 
-        if (res.props.children.props.children[0].key.includes('Emoji')) {
-          res.props.children.props.children[1] = res.props.children.props.children[1].filter(emoji =>
-            !emoji.props.emoji.guildId || !hiddenGuilds.includes(emoji.props.emoji.guildId)
-          );
-        }
-
-        if (res.props.children.props.children[1].length === 0) {
-          return null;
-        }
+      if (autocompleteOptions) {
+        autocompleteOptions.EMOJIS.queryResults = (value) => ({
+          emojis: this.queryEmojiResults(value, channel).emojis.filter(emoji =>
+            !emoji.guildId || !this.getHiddenGuilds().includes(emoji.guildId))
+        });
       }
-      return res;
+
+      return args;
     });
 
     this.registerSettings('pc-emojiUtility', 'Emote Utility', Settings);
@@ -823,6 +824,5 @@ module.exports = class EmojiUtility extends Plugin {
     uninject('pc-emojiUtility-hideEmojisPickerRm');
     uninject('pc-emojiUtility-hideEmojisPickerMount');
     uninject('pc-emojiUtility-hideEmojisComplete');
-    uninject('pc-emojiUtility-hideEmojisCompleteEvent');
   }
 };

--- a/src/Powercord/plugins/pc-emojiUtility/manifest.json
+++ b/src/Powercord/plugins/pc-emojiUtility/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Emote Utility",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Emote related commands",
   "author": "Joakim#9814, Bowser65",
   "license": "MIT"

--- a/src/Powercord/plugins/pc-pluginManager/components/Explore.jsx
+++ b/src/Powercord/plugins/pc-pluginManager/components/Explore.jsx
@@ -42,12 +42,15 @@ module.exports = class Explore extends React.Component {
 
   render () {
     return <div className='powercord-plugins'>
-      <div className='powercord-plugins-wip'>
+      <div className='ghostPill-2-KUPM powercord-plugins-wip'>
         This part of Powercord is a WIP. Expect unavailable features and crashes here
       </div>
       <div className='powercord-plugins-header'>
         <h3>Explore plugins</h3>
         <Button onClick={() => this.props.goToInstalled()}>Installed Plugins</Button>
+        <div class='powercord-folders-opener'>
+          <Button color={Button.Colors.WHITE} look={Button.Looks.OUTLINED} onClick={() => this.props.openFolder(powercord.pluginManager.pluginDir)}>Open Plugins Folder</Button>
+        </div>
       </div>
       <Divider/>
       <div className='powercord-plugins-topbar'>

--- a/src/Powercord/plugins/pc-pluginManager/components/Installed.jsx
+++ b/src/Powercord/plugins/pc-pluginManager/components/Installed.jsx
@@ -4,8 +4,6 @@ const { TextInput } = require('powercord/components/settings');
 const { open: openModal, close: closeModal } = require('powercord/modal');
 const { asyncArray: { map } } = require('powercord/util');
 const { Confirm } = require('powercord/components/modal');
-const { spawn } = require('child_process');
-const { resolve } = require('path');
 const Plugin = require('./Plugin');
 
 module.exports = class Installed extends React.Component {
@@ -15,38 +13,20 @@ module.exports = class Installed extends React.Component {
     this.state = {
       search: ''
     };
-
-    this.openFolder = (dir) => {
-      const cmds = {
-        win32: 'explorer',
-        darwin: 'open',
-        linux: 'xdg-open'
-      };
-      spawn(cmds[process.platform], [ dir ]);
-    };
-
-    this.openPluginsFolder = () => {
-      this.openFolder(resolve(__dirname, '..', '..'));
-    };
-
-    this.openThemesFolder = () => {
-      this.openFolder(resolve(__dirname, '..', '..', '..', 'themes'));
-    };
   }
 
   render () {
     const plugins = this._getPlugins();
 
     return <div className='powercord-plugins'>
-      <div className="ghostPill-2-KUPM powercord-plugins-wip">
+      <div className='ghostPill-2-KUPM powercord-plugins-wip'>
         This part of Powercord is a WIP. Expect unavailable features and crashes here
       </div>
       <div className='powercord-plugins-header'>
         <h3>Installed plugins</h3>
         <Button onClick={() => this.props.goToExplore()}>Explore Plugins</Button>
-        <div class="powercord-folders-opener">
-          <a onClick={() => this.openPluginsFolder()}>Open Plugins Folder</a>
-          <a onClick={() => this.openThemesFolder()}>Open Themes Folder</a>
+        <div class='powercord-folders-opener'>
+          <Button color={Button.Colors.WHITE} look={Button.Looks.OUTLINED} onClick={() => this.props.openFolder(powercord.pluginManager.pluginDir)}>Open Plugins Folder</Button>
         </div>
       </div>
       <Divider/>

--- a/src/Powercord/plugins/pc-pluginManager/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-pluginManager/components/Settings.jsx
@@ -1,4 +1,5 @@
 const { React } = require('powercord/webpack');
+const { spawn } = require('child_process');
 
 const Installed = require('./Installed');
 const Explore = require('./Explore');
@@ -10,12 +11,21 @@ module.exports = class Settings extends React.Component {
     this.state = {
       explore: false
     };
+
+    this.openFolder = (dir) => {
+      const cmds = {
+        win32: 'explorer',
+        darwin: 'open',
+        linux: 'xdg-open'
+      };
+      spawn(cmds[process.platform], [ dir ]);
+    };
   }
 
   render () {
     if (this.state.explore) {
-      return <Explore goToInstalled={() => this.setState({ explore: false })}/>;
+      return <Explore openFolder={this.openFolder} goToInstalled={() => this.setState({ explore: false })}/>;
     }
-    return <Installed goToExplore={() => this.setState({ explore: true })}/>;
+    return <Installed openFolder={this.openFolder} goToExplore={() => this.setState({ explore: true })}/>;
   }
 };

--- a/src/Powercord/plugins/pc-pluginManager/manifest.json
+++ b/src/Powercord/plugins/pc-pluginManager/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Plugin Manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Powercord's plugin manager",
   "author": "Powercord Team",
   "license": "MIT"

--- a/src/Powercord/plugins/pc-pluginManager/scss/style.scss
+++ b/src/Powercord/plugins/pc-pluginManager/scss/style.scss
@@ -69,6 +69,34 @@
   }
 }
 
+.powercord-folders-opener {
+  margin-left: 15px;
+  flex: 0 0 auto;
+  display: flex;
+
+  button {
+    &:not(:last-child) {
+      margin-right: 15px;
+    }
+  }
+}
+
+.theme-light {
+  .powercord-folders-opener > button {
+    color: #040405;
+    border-color: rgba(4, 4, 5, .3);
+
+    &:active {
+      background-color: rgba(4, 4, 5, .1); 
+      border-color: #040405;
+    }
+
+    &:hover {
+      border-color: rgba(4, 4, 5, .6);
+    }
+  }
+}
+
 // Colors
 .theme-dark .powercord-plugins {
   color: #fff;
@@ -81,16 +109,5 @@
 .theme-light .powercord-plugins {
   &-wip {
     color: #fff;
-  }
-}
-
-.powercord-folders-opener {
-  margin-left: 10px;
-  line-height: 1.5;
-  text-align: right;
-  flex: 0 0 auto;
-
-  a {
-    display: block;
   }
 }

--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -205,7 +205,7 @@ module.exports = class Modal extends React.Component {
       ? (<Tooltip text={libraryStatus.tooltip} position="top">
         <button
           style={{ color: libraryStatus.color }}
-          className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow ${libraryStatus.icon} spotify-in-library`}
+          className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} ${libraryStatus.icon} spotify-in-library`}
           onClick={libraryStatus.action}
         />
       </Tooltip>)
@@ -214,7 +214,7 @@ module.exports = class Modal extends React.Component {
       ? (<Tooltip text="Shuffle" position="top">
         <button
           style={{ color: shuffleColor }}
-          className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
+          className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
           onClick={() => this.onButtonClick('setShuffleState', !this.state.shuffleState)}
         />
       </Tooltip>)
@@ -223,14 +223,14 @@ module.exports = class Modal extends React.Component {
           color: shuffleColor,
           opacity: 0.25
         }}
-        className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
+        className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
         disabled
       />);
     const repeatButton = !this.state.disallowedActions.toggling_repeat_track && !this.state.disallowedActions.toggling_repeat_context
       ? (<Tooltip text={this.repeatStruct[this.state.repeatState].tooltip} position="top">
         <button
           style={{ color: repeatColor }}
-          className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
+          className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
           onClick={() => this.onButtonClick('setRepeatState', this.repeatStruct[this.state.repeatState].next)}
         />
       </Tooltip>)
@@ -239,7 +239,7 @@ module.exports = class Modal extends React.Component {
           color: shuffleColor,
           opacity: 0.25
         }}
-        className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
+        className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
         disabled
       />);
     return <>
@@ -250,15 +250,17 @@ module.exports = class Modal extends React.Component {
         onContextMenu={this.injectContextMenu.bind(this)}
         style={displayState === 'hide' ? { display: 'none' } : {}}
       >
+
         <Tooltip text={currentItem.albumName} position='top'>
-          <div className='avatarWrapper-3B0ndJ'>
+          <div className={containerClasses.avatarWrapper}>
             <div
-              className='wrapper-3t9DeA'
+              className={containerClasses.wrapper}
               style={{
-                backgroundImage: `url("${currentItem.img}")`,
+                backgroundImage: `url(${currentItem.img})`,
                 backgroundSize: 'contain',
-                height: '35px',
-                width: '35px'
+                cursor: 'pointer',
+                height: '32px',
+                width: '32px'
               }}
               onClick={() => shell.openExternal(currentItem.uri)}
             />
@@ -269,14 +271,14 @@ module.exports = class Modal extends React.Component {
           <div className={containerClasses.usernameContainer}>
             <Title className={`${containerClasses.username} username`}>{currentItem.name}</Title>
           </div>
-          <Title className={`${[ containerClasses.discriminator, containerClasses.size10, containerClasses.subtext ].join(' ')} discriminator`}>{artists ? `by ${artists}` : ''}</Title>
+          <Title className={`${[ containerClasses.size10, containerClasses.subtext, containerClasses.discriminator ].join(' ')} discriminator`}>{artists ? `by ${artists}` : ''}</Title>
         </div>
 
-        <div className='flex-1xMQg5 flex-1O1GKY pc-flex pc-flex horizontal-1ae9ci horizontal-2EEEnY flex-1O1GKY directionRow-3v3tfG justifyStart-2NDFzi alignStretch-DpGPf3 noWrap-3jynv6'>
+        <div className={[ containerClasses.flex, containerClasses.horizontal, containerClasses.directionRow, containerClasses.justifyRow, containerClasses.alignStretch, containerClasses.noWrap ].join(' ')}>
           <Tooltip text='Previous' position='top'>
             <button
               style={{ color: '#1ed860' }}
-              className='button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-backward spotify-previous'
+              className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-backward spotify-previous`}
               onClick={() => this.state.seekBar.progress + (Date.now() - this.state.seekBar.progressAt) > 5e3 ? this.onButtonClick('seek', 0) : this.onButtonClick('prev')}
             />
           </Tooltip>
@@ -284,7 +286,7 @@ module.exports = class Modal extends React.Component {
           <Tooltip text={isPlaying ? 'Pause' : 'Play'} position='top'>
             <button
               style={{ color: '#1ed860' }}
-              className={`button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-${isPlaying ? 'pause' : 'play'} spotify-${isPlaying ? 'pause' : 'play'}`}
+              className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${isPlaying ? 'pause' : 'play'} spotify-${isPlaying ? 'pause' : 'play'}`}
               onClick={() => this.onButtonClick(isPlaying ? 'pause' : 'play')}
             />
           </Tooltip>
@@ -292,7 +294,7 @@ module.exports = class Modal extends React.Component {
           <Tooltip text='Next' position='top'>
             <button
               style={{ color: '#1ed860' }}
-              className='button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grow fas fa-forward spotify-next'
+              className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-forward spotify-next`}
               onClick={() => this.onButtonClick('next')}
             />
           </Tooltip>
@@ -318,7 +320,7 @@ module.exports = class Modal extends React.Component {
               {powercord.account && powercord.account.spotify && <Tooltip text="Save to Playlist" position="top">
                 <button
                   style={{ color: '#fff' }}
-                  className='button-2JbWXs pc-button button-38aScr pc-button lookBlank-3eh9lL colorBrand-3pXr91 grow-q77ONN pc-grows fas fa-plus-circle spotify-save-to-playlist'
+                  className={`${`${[ containerClasses.button, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-plus-circle spotify-save-to-playlist`}
                   onClick={() => powercord.pluginManager.get('pc-spotify').openPlaylistModal(currentItem.uri)}
                 />
               </Tooltip>}
@@ -336,7 +338,7 @@ module.exports = class Modal extends React.Component {
       this.state,
       this.onButtonClick,
       powercord.account && powercord.account.spotify,
-      !this.props.showAdvanced,
+      !this.props.getSetting('showControls', true),
       !this.props.getSetting('showContextIcons', true)
     );
     contextMenu.openContextMenu(e, () =>

--- a/src/Powercord/plugins/pc-spotify/Modal/Title.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Title.jsx
@@ -11,10 +11,10 @@ module.exports = class Title extends React.Component {
   }
 
   render () {
-    // @todo: make dynamic
-    this.canvas.font = 'normal normal 400 normal 14px / 14px Whitney, "Helvetica Neue", Helvetica, Arial, sans-serif';
+    const titleElement = document.querySelector(`.${this.props.className.replace(/ /g, '.')}`);
+    this.canvas.font = titleElement ? getComputedStyle(titleElement).font : null;
     const titleWidth = Math.ceil(this.canvas.measureText(this.props.children).width);
-    const animationDuration = (titleWidth - 84) * 90;
+    const animationDuration = (titleWidth - 78) * 90;
     let { className } = this.props;
     if (this.state.hovered) {
       className += ' translating';
@@ -22,13 +22,13 @@ module.exports = class Title extends React.Component {
 
     return (
       <span
-        onMouseEnter={() => this.setState({ hovered: titleWidth > 84 })}
+        onMouseEnter={() => this.setState({ hovered: titleWidth > 78 })}
         onMouseLeave={() => this.setState({ hovered: false })}
         className={className}
         style={{
           animationDuration: `${animationDuration}ms`,
-          width: this.state.hovered ? titleWidth : 84,
-          maxWidth: this.state.hovered ? titleWidth : 84
+          width: this.state.hovered ? titleWidth : 78,
+          maxWidth: this.state.hovered ? titleWidth : 78
         }}
       >{this.props.children}</span>
     );

--- a/src/Powercord/plugins/pc-spotify/Modal/contextMenuGroups.js
+++ b/src/Powercord/plugins/pc-spotify/Modal/contextMenuGroups.js
@@ -118,7 +118,11 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden, hasIco
       getItems: () => [ {
         type: 'submenu',
         name: 'Repeat Modes',
-        image: hasIconsHidden ? '' : 'fa-sync',
+      image: hasIconsHidden
+        ? ''
+        : state.repeatState === 'context'
+          ? 'fa-sync'
+          : 'fa-undo',
         getItems: () => [ {
           name: 'On',
           stateName: 'context'
@@ -148,7 +152,10 @@ module.exports = (state, onButtonClick, hasCustomAuth, hasControlsHidden, hasIco
     type: 'slider',
     name: 'Volume',
     color: '#1ed860',
+    className: 'powercord-spotify-volumeSlider',
     defaultValue: state.volume,
+    equidistant: true,
+    markers: [ 0, 20, 40, 60, 80, 100 ],
     onValueChange: (val) =>
       SpotifyPlayer.setVolume(Math.round(val))
         .then(() => true)

--- a/src/Powercord/plugins/pc-spotify/SpotifyPlayer.js
+++ b/src/Powercord/plugins/pc-spotify/SpotifyPlayer.js
@@ -59,19 +59,21 @@ module.exports = {
 
     return request
       .catch(async (err) => {
-        if (err.statusCode === 401) {
-          this.accessToken = await this.getAccessToken();
+        if (err) {
+          if (err.statusCode === 401) {
+            this.accessToken = await this.getAccessToken();
 
-          delete request._res;
-          return this.genericRequest(request);
-        }
+            delete request._res;
+            return this.genericRequest(request);
+          }
 
-        if (err.body.error && err.body.error.reason === 'PREMIUM_REQUIRED') {
-          powercord.pluginManager.get('pc-spotify').openPremiumDialog();
-          return false;
+          if (err.body && err.body.error && err.body.error.reason === 'PREMIUM_REQUIRED') {
+            powercord.pluginManager.get('pc-spotify').openPremiumDialog();
+            return false;
+          }
+          console.error(err.body, request.opts);
+          throw err;
         }
-        console.error(err.body, request.opts);
-        throw err;
       });
   },
 

--- a/src/Powercord/plugins/pc-spotify/index.js
+++ b/src/Powercord/plugins/pc-spotify/index.js
@@ -22,7 +22,11 @@ module.exports = class Spotify extends Plugin {
     this.loadCSS(resolve(__dirname, 'style.scss'));
     this.containerClasses = {
       ...await getModule([ 'container', 'usernameContainer' ]),
+      ...await getModule([ 'button', 'lookFilled' ]),
+      ...await getModule([ 'wrapper', 'avatar' ]),
+      ...await getModule([ 'button', 'buttonIcon', 'disabled' ]),
       ...await getModule([ 'size10', 'size12' ]),
+      ...await getModule([ 'flex' ]),
       ...await getModule(m => Object.keys(m).join('') === 'subtext')
     };
     this._injectModal();

--- a/src/Powercord/plugins/pc-spotify/manifest.json
+++ b/src/Powercord/plugins/pc-spotify/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spotify Modal",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Better Spotify integration in Discord",
   "author": "Powercord Team",
   "license": "MIT"

--- a/src/Powercord/plugins/pc-spotify/style.scss
+++ b/src/Powercord/plugins/pc-spotify/style.scss
@@ -70,21 +70,13 @@
   }
 
   .username {
-    color: #fff;
-    overflow: hidden;
     position: absolute;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     top: 0;
   }
 
   .discriminator {
     bottom: 0;
-    max-width: 84px;
-    overflow: hidden;
     position: absolute;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .translating {
@@ -195,6 +187,10 @@
       padding-bottom: 15px;
     }
   }
+
+  &-volumeSlider {
+    margin-top: 10px;
+  }
 }
 
 @keyframes spotifyText {
@@ -203,6 +199,6 @@
   }
 
   75%, 100% {
-    transform: translateX(calc(-100% + 84px));
+    transform: translateX(calc(-100% + 78px));
   }
 }


### PR DESCRIPTION
### Plugin Changelog:

```ini
[Announcements]
    # Notice.jsx:
      - Move 'classesStore' variable inside `constructor()`.
      - Change default value of 'types' to "{}".
      - Replace single-line comment (line 66 -> 67) with a multi-line block.

    # index.js:
      - Remove `_forceUpdate()` and replace all calls with the built-in 'forceUpdateElement' helper method.
      - Update 'onClick' action for "pc-first-welcome" announcement - no longer throws an error and
        actually selects 'Powercord' as well as the last selected channel.

    # manifest.json:
      - Bump version number from '0.1.1' to '0.1.2'.

[Class Name Normalizer]
    # index.js:
      - Resolve 'prototype' being `undefined` (return of the `data-guild-id` data attribute!).

[Clickable Edits]
    # index.js:
      - Similar to the first change of the 'index.js' file for Announcements - remove `forceUpdate` method.
      - Add 'container' to the list of possible edits (TL;DR Images are now double-clickable/editable).

    # manifest.json:
      - Bump version number from '0.1.4' to '0.2.0'.

[Emoji Utility]
    # index.js:
      - Hidden emojis now serve to their name and are actually HIDDEN from autocomplete (closes #117)
        ; also closes #177 as the subject has been eradicated. 

    # index.js / Settings.jsx:
      - Replace all occurrences of `getSortedGuilds` with `getFlattenedGuilds` (resolves missing guilds).

    # manifest.json:
      - Bump version number from '1.3.2' to '1.3.3'.

[Plugin Manager]
    # Explore.jsx:
      - Instead of leaving the 'Open Plugins Folder' button in "Installed Plugins" why not add it here as well.

    # Installed.jsx:
      - Move `openFolder()` to Settings.jsx (let''s make things a little more tidy and less cramp, shall we).
      - Replace folder hyperlinks with some fresh new buttons.

    # Settings.jsx:
      - (please refer to the first change of 'Installed.jsx' found above).

    # style.css:
      - Add additional styling to 'powercord-folders-opener' class (buttons also adapt for light theme users).

    # manifest.json:
      - Bump version number from '0.1.0' to '0.1.1'.

[Spotify]
    # SpotifyPlayer.js:
      - Introduce a condition that checks if an error does in fact exist (should help with false-positives).

    # index.js:
      - Add more classes to 'containerClasses' variable - we''ll use these for fetching class names dynamically within 'Modal.jsx'.

    # style.css:
      - Remove some instances of duplicated attributes (ones that have already been declared by Discord).
      - Make a new class for the volume slider that adds a 10 pixels top-margin.
      - Adjust the spotifyText 'transform' attribute used from 75-100%, fixing the unfinished animation cycle for sliding text. 

    # Modal.jsx:
      - As already brought up in the changes for 'index.js', class names are now retrieved from 'containerClasses'.
      - Reduce width and height for artwork image to "32px" and change the cursor to a pointer when hovered.
      - Advanced controls actually get displayed/are hidden in the Spotify context menu now.

    # Title.jsx:
      - Font size for title is now dynamically set and is persistent over 'Streamer Mode' being enabled (closes #64).
      - Title now properly scrolls through text upon hover (previously used to cut some text off - this has now been
        resolved!).

    # contextMenuGroups.js:
      - Change "Playback Settings" icon to a sync indicator if the repeat state is 'On'.
      - Add text markers to volume slider.

    # manifest.json:
      - Bump version number from '1.0.0' to '1.1.0'.
```