### PR TITLE
Little OCD fix

### DIFF
--- a/src/Powercord/plugins/pc-commands/commands/help.js
+++ b/src/Powercord/plugins/pc-commands/commands/help.js
@@ -28,7 +28,7 @@ module.exports = {
     } else {
       const command = powercord.api.commands.commands.find(c => [ c.command, ...c.aliases ].includes(commandName));
       if (!command) {
-        result = `Command \`${commandName}\` not found.`;
+        result = `Command ${powercord.api.commands.prefix}\`${commandName}\` not found.`;
       } else {
         result = {
           type: 'rich',

--- a/src/Powercord/plugins/pc-commands/commands/help.js
+++ b/src/Powercord/plugins/pc-commands/commands/help.js
@@ -28,7 +28,7 @@ module.exports = {
     } else {
       const command = powercord.api.commands.commands.find(c => [ c.command, ...c.aliases ].includes(commandName));
       if (!command) {
-        result = `Command ${powercord.api.commands.prefix}\`${commandName}\` not found.`;
+        result = `Command \`${commandName}\` not found.`;
       } else {
         result = {
           type: 'rich',

--- a/src/Powercord/plugins/pc-spotify/commands/next.js
+++ b/src/Powercord/plugins/pc-spotify/commands/next.js
@@ -1,7 +1,7 @@
 module.exports = {
   command: 'next',
   description: 'Skip Spotify song',
-  usage: '/next',
+  usage: '{c}',
 
   func (SpotifyPlayer) {
     return SpotifyPlayer.next();

--- a/src/Powercord/plugins/pc-spotify/commands/pause.js
+++ b/src/Powercord/plugins/pc-spotify/commands/pause.js
@@ -1,7 +1,7 @@
 module.exports = {
   command: 'pause',
   description: 'Pause Spotify playback',
-  usage: '/pause',
+  usage: '{c}',
 
   func (SpotifyPlayer) {
     return SpotifyPlayer.pause();

--- a/src/Powercord/plugins/pc-spotify/commands/play.js
+++ b/src/Powercord/plugins/pc-spotify/commands/play.js
@@ -3,7 +3,7 @@ const urlRegex = /\/track\/([A-z0-9]*)/;
 module.exports = {
   command: 'play',
   description: 'Play a Spotify URL',
-  usage: '/play <URL>',
+  usage: '{c} <URL>',
 
   async func (SpotifyPlayer, [ url ]) {
     if (!url) {

--- a/src/Powercord/plugins/pc-spotify/commands/previous.js
+++ b/src/Powercord/plugins/pc-spotify/commands/previous.js
@@ -2,7 +2,7 @@ module.exports = {
   command: 'previous',
   aliases: [ 'prev' ],
   description: 'Go back one Spotify song',
-  usage: '/previous',
+  usage: '{c}',
 
   func (SpotifyPlayer) {
     return SpotifyPlayer.prev();

--- a/src/Powercord/plugins/pc-spotify/commands/resume.js
+++ b/src/Powercord/plugins/pc-spotify/commands/resume.js
@@ -1,7 +1,7 @@
 module.exports = {
   command: 'resume',
   description: 'Resume Spotify playback',
-  usage: '/resume',
+  usage: '{c}',
 
   func (SpotifyPlayer) {
     return SpotifyPlayer.play();

--- a/src/Powercord/plugins/pc-spotify/commands/share.js
+++ b/src/Powercord/plugins/pc-spotify/commands/share.js
@@ -3,7 +3,7 @@ const { messages, channels } = require('powercord/webpack');
 module.exports = {
   command: 'share',
   description: 'Send currently playing song to channel.',
-  usage: '/share',
+  usage: '{c}',
 
   async func (SpotifyPlayer) {
     if (SpotifyPlayer.player.item.external_urls) {

--- a/src/Powercord/plugins/pc-spotify/commands/volume.js
+++ b/src/Powercord/plugins/pc-spotify/commands/volume.js
@@ -2,7 +2,7 @@ module.exports = {
   command: 'volume',
   aliases: [ 'vol' ],
   description: 'Change Spotify volume',
-  usage: '/volume <number between 0-100>',
+  usage: '{c} <number between 0-100>',
 
   func (SpotifyPlayer, [ args ]) {
     return SpotifyPlayer.setVolume(args);

--- a/src/Powercord/plugins/pc-tags/commands/add.js
+++ b/src/Powercord/plugins/pc-tags/commands/add.js
@@ -1,3 +1,5 @@
+const getPrefix = () => powercord.api.commands.prefix;
+
 module.exports = {
   command: 'add',
   description: 'Create a tag',
@@ -8,7 +10,7 @@ module.exports = {
         result: {
           type: 'rich',
           title: 'Missing required arguments',
-          footer: { text: 'Refer to /help tag' }
+          footer: { text: `Refer to ${getPrefix()}help tag` }
         }
       };
     }
@@ -20,7 +22,7 @@ module.exports = {
         send: false,
         result: {
           type: 'rich',
-          title: `Tag "${name}" already exists (use /tag update)`
+          title: `Tag "${name}" already exists (use ${getPrefix()}tag update)`
         }
       };
     }

--- a/src/Powercord/plugins/pc-tags/commands/update.js
+++ b/src/Powercord/plugins/pc-tags/commands/update.js
@@ -1,3 +1,5 @@
+const getPrefix = () => powercord.api.commands.prefix;
+
 module.exports = {
   command: 'update',
   description: 'Update a tag',
@@ -8,7 +10,7 @@ module.exports = {
         result: {
           type: 'rich',
           title: 'Missing required arguments',
-          footer: { text: 'Refer to /help tag' }
+          footer: { text: `Refer to ${getPrefix()}help tag` }
         }
       };
     }


### PR DESCRIPTION
Whenever you do .help cmd (any command) it says the usage is `/cmd` no matter what. Changed that to use the users prefix