### PR TITLE
Fix Coloring in Light theme for the Spotify Modal

### DIFF
--- a/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
+++ b/src/Powercord/plugins/pc-spotify/Modal/Modal.jsx
@@ -176,14 +176,11 @@ module.exports = class Modal extends React.Component {
     const artists = concat(currentItem.artists);
     const { containerClasses } = this.props.main;
 
-    const shuffleColor = this.state.shuffleState ? '#1ed860' : '#fff';
-    const repeatColor = this.state.repeatState === 'off' ? '#fff' : '#1ed860';
     const repeatIcon = this.state.repeatState === 'context' ? 'sync' : 'undo';
     const libraryStatus = this.state.inLibrary === false
       ? {
         tooltip: 'Save to Liked Songs',
         icon: 'far fa-heart',
-        color: '#fff',
         action: () => {
           SpotifyPlayer.addSong(this.state.currentItem.id).then(() => {
             this.setState({ inLibrary: !this.state.inLibrary });
@@ -192,8 +189,7 @@ module.exports = class Modal extends React.Component {
       }
       : {
         tooltip: 'Remove from Liked Songs',
-        icon: 'fas fa-heart',
-        color: '#1ed860',
+        icon: 'fas fa-heart active',
         action: () => {
           SpotifyPlayer.removeSong(this.state.currentItem.id).then(() => {
             this.setState({ inLibrary: !this.state.inLibrary });
@@ -204,7 +200,6 @@ module.exports = class Modal extends React.Component {
     const libraryButton = this.state.inLibrary !== ''
       ? (<Tooltip text={libraryStatus.tooltip} position="top">
         <button
-          style={{ color: libraryStatus.color }}
           className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} ${libraryStatus.icon} spotify-in-library`}
           onClick={libraryStatus.action}
         />
@@ -213,33 +208,29 @@ module.exports = class Modal extends React.Component {
     const shuffleButton = !this.state.disallowedActions.toggling_shuffle
       ? (<Tooltip text="Shuffle" position="top">
         <button
-          style={{ color: shuffleColor }}
-          className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
+          className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'} ${this.state.shuffleState ? 'active' : ''}`}
           onClick={() => this.onButtonClick('setShuffleState', !this.state.shuffleState)}
         />
       </Tooltip>)
       : (<button
         style={{
-          color: shuffleColor,
           opacity: 0.25
         }}
-        className={`${`${[ containerClasses.button, containerClasses.disabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'}`}
+        className={`${`${[ containerClasses.button, containerClasses.disabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-random spotify-shuffle-${this.state.shuffleState ? 'on' : 'off'} ${this.state.shuffleState ? 'active' : ''}`}
         disabled
       />);
     const repeatButton = !this.state.disallowedActions.toggling_repeat_track && !this.state.disallowedActions.toggling_repeat_context
       ? (<Tooltip text={this.repeatStruct[this.state.repeatState].tooltip} position="top">
         <button
-          style={{ color: repeatColor }}
-          className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
+          className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState} ${this.state.repeatState !== 'off' ? 'active' : ''}`}
           onClick={() => this.onButtonClick('setRepeatState', this.repeatStruct[this.state.repeatState].next)}
         />
       </Tooltip>)
       : (<button
         style={{
-          color: shuffleColor,
           opacity: 0.25
         }}
-        className={`${`${[ containerClasses.button, containerClasses.disabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState}`}
+        className={`${`${[ containerClasses.button, containerClasses.disabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-${repeatIcon} spotify-repeat-${this.state.repeatState} ${this.state.repeatState !== 'off' ? 'active' : ''}`}
         disabled
       />);
 
@@ -320,7 +311,6 @@ module.exports = class Modal extends React.Component {
 
               {powercord.account && powercord.account.spotify && <Tooltip text="Save to Playlist" position="top">
                 <button
-                  style={{ color: '#fff' }}
                   className={`${`${[ containerClasses.button, containerClasses.enabled, containerClasses.lookBlank, containerClasses.colorBrand, containerClasses.grow ].join(' ')}`} fas fa-plus-circle spotify-save-to-playlist`}
                   onClick={() => powercord.pluginManager.get('pc-spotify').openPlaylistModal(currentItem.uri)}
                 />

--- a/src/Powercord/plugins/pc-spotify/style.scss
+++ b/src/Powercord/plugins/pc-spotify/style.scss
@@ -193,8 +193,8 @@ div[class*='listeningAlong'] + .powercord-spotify {
 
 .powercord-spotify-seek-btngrp button{
   color: var(--text-normal);
-  &.active{
-    color: #1ed860!important;
+  &.active, &.active:hover{
+    color: #1ed860;
   }
 }
 

--- a/src/Powercord/plugins/pc-spotify/style.scss
+++ b/src/Powercord/plugins/pc-spotify/style.scss
@@ -38,11 +38,11 @@ div[class*='listeningAlong'] + .powercord-spotify {
     padding: 4px;
     align-items: center;
     width: 45%;
-    border: 1px solid #2f3136;
+    border: 1px solid var(--text-normal);
     border-radius: 4px;
     margin-top: 5px;
     margin-bottom: 5px;
-    color: white;
+    color: var(--text-normal);
 
     .image {
       margin-right: 10px;
@@ -50,7 +50,7 @@ div[class*='listeningAlong'] + .powercord-spotify {
     }
 
     &-modal-header {
-      color: white;
+      color: var(--text-normal);
       font-weight: bold;
       text-transform: uppercase;
     }
@@ -60,13 +60,14 @@ div[class*='listeningAlong'] + .powercord-spotify {
       justify-content: space-evenly;
       flex-wrap: wrap;
       padding-bottom: 5px;
-      color: white;
+      color: var(--text-normal);
     }
   }
 
   &-playlist:hover {
     cursor: pointer;
-    background: #2f3136;
+    background: var(--text-normal);
+    color: var(--background-primary);
   }
 
   .username {
@@ -187,6 +188,13 @@ div[class*='listeningAlong'] + .powercord-spotify {
     &:hover {
       padding-bottom: 15px;
     }
+  }
+}
+
+.powercord-spotify-seek-btngrp button{
+  color: var(--text-normal);
+  &.active{
+    color: #1ed860!important;
   }
 }
 


### PR DESCRIPTION
Addresses some issues concerning light theme and the spotify modal.
![image](https://user-images.githubusercontent.com/29519722/66008646-a337c500-e4b7-11e9-9ba0-5401de8e2152.png)
Dark Theme:
![image](https://user-images.githubusercontent.com/29519722/66008738-f6aa1300-e4b7-11e9-8ba6-81a8e1a7123e.png)

Before:
![image](https://user-images.githubusercontent.com/29519722/66008669-b3e83b00-e4b7-11e9-9959-61b239528bc1.png)


The playlist modal has also been fixed to use Discords font variables:
![image](https://user-images.githubusercontent.com/29519722/66008707-d5e1bd80-e4b7-11e9-9a3f-24860c858ff0.png)
Dark Theme:
![image](https://user-images.githubusercontent.com/29519722/66008721-e5f99d00-e4b7-11e9-8b63-0b1f5868dd54.png)
