### PR TITLE
Fixes for announcement plugin and codeblocks

### DIFF
--- a/src/Powercord/plugins/pc-announcements/index.js
+++ b/src/Powercord/plugins/pc-announcements/index.js
@@ -37,7 +37,7 @@ module.exports = class Announcements extends Plugin {
             const { acceptInvite } = (await getModule([ 'acceptInvite' ]));
             const { transitionToGuildSync } = (await getModule([ 'selectGuild' ]));
 
-            if (getGuilds()[GUILD_ID]) {
+            if (!getGuilds()[GUILD_ID]) {
               return acceptInvite(DISCORD_INVITE, {}, () => {
                 transitionToGuildSync(GUILD_ID, false);
               });

--- a/src/Powercord/plugins/pc-codeblocks/index.js
+++ b/src/Powercord/plugins/pc-codeblocks/index.js
@@ -23,7 +23,7 @@ module.exports = class Codeblocks extends Plugin {
     }
   }
 
-  async injectMessage() {
+  async injectMessage () {
     const _this = this;
 
     const messageClasses = await getModule(['container']);

--- a/src/Powercord/plugins/pc-codeblocks/index.js
+++ b/src/Powercord/plugins/pc-codeblocks/index.js
@@ -31,19 +31,7 @@ module.exports = class Codeblocks extends Plugin {
 
     const instance = getOwnerInstance(await waitFor(messageQuery));
     inject('pc-message-codeblock', instance.__proto__, 'render', function (_, res) {
-      if (!res.props.children[1]) {
-        return res;
-      }
-
-      const { message } = res.props.children[1]
-        ? (res.props.children[0] !== false
-          ? res
-            .props.children[1]
-            .props.children[0]
-          : res
-            .props.children[1])
-          .props
-        : null;
+      const { message } = this.props;
 
       let hasCodeblock;
 

--- a/src/Powercord/plugins/pc-codeblocks/index.js
+++ b/src/Powercord/plugins/pc-codeblocks/index.js
@@ -26,7 +26,7 @@ module.exports = class Codeblocks extends Plugin {
   async injectMessage () {
     const _this = this;
 
-    const messageClasses = await getModule(['container']);
+    const messageClasses = await getModule([ 'container', 'messageCompact' ]);
     const messageQuery = `.${messageClasses.container.replace(/ /g, '.')} > div`;
 
     const instance = getOwnerInstance(await waitFor(messageQuery));

--- a/src/Powercord/plugins/pc-codeblocks/index.js
+++ b/src/Powercord/plugins/pc-codeblocks/index.js
@@ -23,11 +23,11 @@ module.exports = class Codeblocks extends Plugin {
     }
   }
 
-  async injectMessage () {
+  async injectMessage() {
     const _this = this;
 
-    const messageClasses = await getModule([ 'container', 'messageCompact' ]);
-    const messageQuery = `.${messageClasses.content.replace(/ /g, '.')}`;
+    const messageClasses = await getModule(['container']);
+    const messageQuery = `.${messageClasses.container.replace(/ /g, '.')} > div`;
 
     const instance = getOwnerInstance(await waitFor(messageQuery));
     inject('pc-message-codeblock', instance.__proto__, 'render', function (_, res) {


### PR DESCRIPTION
Codeblocks didn't work correctly with compact mode, only working on plugin remount. 
Fixed it to work with both modes.

Announcement plugin didn't invite people to the powercord discord correctly when not in the server already. (only went to the server when already on it) 
-> maybe remove the if check completely since people on it might have problems with their install and want assistance?

(Also Github shows some line as marked and idk, i probably broke something again aaaa)