### PR TITLE
feat: use Sucrase to transform JSX files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 
 src/Powercord/plugins/*
 !src/Powercord/plugins/pc-*

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/powercord-org/powercord#readme",
   "dependencies": {
-    "buble": "0.19.6",
     "less": "^3.9.0",
     "node-watch": "^0.6.1",
     "sass": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "less": "^3.9.0",
     "node-watch": "^0.6.1",
     "sass": "^1.18.0",
-    "stylus": "^0.54.5"
+    "stylus": "^0.54.5",
+    "sucrase": "^3.10.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/src/Powercord/modules/jsx.js
+++ b/src/Powercord/modules/jsx.js
@@ -16,16 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const buble = require('buble');
+const sucrase = require('sucrase');
 const { readFileSync } = require('fs');
 
 module.exports = () =>
   require.extensions['.jsx'] = (_module, filename) =>
     _module._compile(
-      buble.transform(readFileSync(filename, 'utf8'), {
-        jsx: 'React.createElement',
-        objectAssign: 'Object.assign',
-        target: { chrome: 52 }
+      sucrase.transform(readFileSync(filename, 'utf8'), {
+        transforms: ['jsx']
       }).code,
       filename
     );

--- a/src/Powercord/modules/jsx.js
+++ b/src/Powercord/modules/jsx.js
@@ -23,7 +23,8 @@ module.exports = () =>
   require.extensions['.jsx'] = (_module, filename) =>
     _module._compile(
       sucrase.transform(readFileSync(filename, 'utf8'), {
-        transforms: [ 'jsx' ]
+        transforms: [ 'jsx' ],
+        filePath: filename
       }).code,
       filename
     );

--- a/src/Powercord/modules/jsx.js
+++ b/src/Powercord/modules/jsx.js
@@ -23,7 +23,7 @@ module.exports = () =>
   require.extensions['.jsx'] = (_module, filename) =>
     _module._compile(
       sucrase.transform(readFileSync(filename, 'utf8'), {
-        transforms: ['jsx']
+        transforms: [ 'jsx' ]
       }).code,
       filename
     );


### PR DESCRIPTION
Sucrase is somewhat faster than Buble, since it only targets modern JS runtimes. Hopefully with this pull request, even if it mostly only benefits large JSX files, should reduce the transpilation time on startup.

### Small testing
Done on Arch Linux <!-- ftw --> with a Core i3-5005U and 8GB of RAM  
`performance.now` on start and end of transpilation

- `src/fake_node_modules/powercord/components/ContextMenu/ContextMenu.jsx`
  - buble: `133.40ms`
  - sucrase: `92.46ms`
- `src/Powercord/plugins/pc-spotify/Modal/Modal.jsx`
  - buble: `59.91ms`
  - sucrase: `45.10ms`
- `src/Powercord/plugins/pc-pluginManager/components/Settings.jsx`
  - buble: `103.42ms`
  - sucrase: `63.27ms`