### PR TITLE
Make the updater not take 10 hours

### DIFF
--- a/src/Powercord/apis/settings/store/index.js
+++ b/src/Powercord/apis/settings/store/index.js
@@ -22,7 +22,6 @@ const { writeFile, mkdir } = require('fs').promises;
 
 const { Flux, FluxDispatcher } = require('powercord/webpack');
 const { SETTINGS_FOLDER } = require('powercord/constants');
-const { sleep } = require('powercord/util');
 
 const { loadSettings } = require('./actions');
 const reducer = require('./reducer');
@@ -63,12 +62,12 @@ class SettingsStore extends Flux.Store {
     return Object.keys(this.getSettings(category));
   }
 
-  static pending = [];
-  static emptying = false;
-
   static async _persist (category, settings) {
     // Let's not write concurrently
-    SettingsStore.pending.push({ category, settings });
+    SettingsStore.pending.push({
+      category,
+      settings
+    });
     SettingsStore._triggerQueue();
   }
 
@@ -87,12 +86,14 @@ class SettingsStore extends Flux.Store {
     await writeFile(join(SETTINGS_FOLDER, `${category}.json`), JSON.stringify(settings, null, 2));
 
     if (SettingsStore.pending.length !== 0) {
-      SettingsStore._nextQueueItem()
+      SettingsStore._nextQueueItem();
     } else {
       SettingsStore.emptying = false;
     }
   }
 }
+SettingsStore.pending = [];
+SettingsStore.emptying = false;
 
 const store = new SettingsStore();
 module.exports = store;

--- a/src/Powercord/plugins/pc-updater/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-updater/components/Settings.jsx
@@ -107,7 +107,7 @@ module.exports = class UpdaterSettings extends React.Component {
           </Button>}
           <Button
             size={Button.Sizes.SMALL}
-            onClick={() => this.plugin.checkForUpdates()}
+            onClick={() => this.plugin.checkForUpdates(Infinity)}
           >
             Check for Updates
           </Button>

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -48,7 +48,7 @@ module.exports = class Updater extends Plugin {
     clearInterval(this._interval);
   }
 
-  async checkForUpdates () {
+  async checkForUpdates (concurrency = 2) {
     if (
       this.settings.set('disabled', false) ||
       this.settings.set('paused', false) ||
@@ -71,10 +71,9 @@ module.exports = class Updater extends Plugin {
     }
 
     // Not the prettiest way to limit concurrency but it works
-    const limit = Infinity;
     const groupedEntities = [];
-    for (let i = 0; i < entities.length; i += limit) {
-      groupedEntities.push(entities.slice(i, i + limit));
+    for (let i = 0; i < entities.length; i += concurrency) {
+      groupedEntities.push(entities.slice(i, i + concurrency));
     }
 
     let done = 0;

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -71,9 +71,10 @@ module.exports = class Updater extends Plugin {
     }
 
     // Not the prettiest way to limit concurrency but it works
+    const limit = Infinity;
     const groupedEntities = [];
-    for (let i = 0; i < entities.length; i += 2) {
-      groupedEntities.push([ entities[i], entities[i + 1] ]);
+    for (let i = 0; i < entities.length; i += limit) {
+      groupedEntities.push(entities.slice(i, i+limit));
     }
 
     let done = 0;

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -74,7 +74,7 @@ module.exports = class Updater extends Plugin {
     const limit = Infinity;
     const groupedEntities = [];
     for (let i = 0; i < entities.length; i += limit) {
-      groupedEntities.push(entities.slice(i, i+limit));
+      groupedEntities.push(entities.slice(i, i + limit));
     }
 
     let done = 0;


### PR DESCRIPTION
- Settings API concurrent write protection is no longer bowserware
- Extract magic fields to updater concurrency number, currently set to Infinity

There were no issues with updating all plugin repos at the same time with my legacy plugin updater extension, so why are you checking for updates in small batches here?

Eslint is screaming at me, but I don't know how to fix that.

Works on my machine.