### PR TITLE
 More visible error message.

### DIFF
--- a/src/Powercord/managers/styles/index.js
+++ b/src/Powercord/managers/styles/index.js
@@ -86,13 +86,14 @@ module.exports = class StyleManager {
       } else {
         const manifest = require(resolve(this.themesDir, filename, 'powercord_manifest.json'));
         if (!this.manifestKeys.every(key => manifest.hasOwnProperty(key))) {
-          return powercord.api.notices.sendAnnouncement('invalid-theme-manifest', {
-            color: 'orange',
-            message: `Theme "${themeID}" doesn't have a valid manifest`,
-            button: {
-              text: 'Generate manifest',
-              onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator/')
-            }
+          return powercord.api.notices.sendToast('invalid-theme-manifest', {
+            header: `Theme "${themeID}" doesn't have a valid manifest`,
+            type: 'danger',
+            buttons: [ {
+              text: 'Generate Manifest',
+              look: 'ghost',
+              onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator')
+            } ]
           });
         }
 
@@ -110,13 +111,14 @@ module.exports = class StyleManager {
         }, true);
       }
     } catch (e) {
-      return powercord.api.notices.sendAnnouncement('invalid-theme-manifest', {
-        color: 'orange',
-        message: `Theme "${themeID}" doesn't have a valid manifest or is not a valid file`,
-        button: {
-          text: 'Generate manifest',
-          onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator/')
-        }
+      return powercord.api.notices.sendToast('invalid-theme-manifest', {
+        header: `Theme "${themeID}" doesn't have a valid manifest or is not a valid file`,
+        type: 'danger',
+        buttons: [ {
+          text: 'Generate Manifest',
+          look: 'ghost',
+          onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator')
+        } ]
       });
     }
 

--- a/src/Powercord/managers/styles/index.js
+++ b/src/Powercord/managers/styles/index.js
@@ -19,6 +19,7 @@
 const { resolve } = require('path');
 const { readdirSync } = require('fs');
 const { lstat } = require('fs').promises;
+const { shell: { openExternal } } = require('electron');
 
 const { Theme } = require('powercord/entities');
 
@@ -85,7 +86,14 @@ module.exports = class StyleManager {
       } else {
         const manifest = require(resolve(this.themesDir, filename, 'powercord_manifest.json'));
         if (!this.manifestKeys.every(key => manifest.hasOwnProperty(key))) {
-          return console.error('%c[Powercord]', 'color: #7289da', `Theme "${themeID}" doesn't have a valid manifest - Skipping`);
+          return powercord.api.notices.sendAnnouncement('invalid-theme-manifest', {
+            color: 'orange',
+            message: `Theme "${themeID}" doesn't have a valid manifest`,
+            button: {
+              text: 'Generate manifest',
+              onClick: () => openExternal(`https://ghostlydilemma.github.io/powercord-manifest-generator/`)
+            }
+          })
         }
 
         if (!window.__OVERLAY__ && manifest.theme) {
@@ -102,7 +110,14 @@ module.exports = class StyleManager {
         }, true);
       }
     } catch (e) {
-      return console.error('%c[Powercord]', 'color: #7289da', `Theme "${themeID}" doesn't have a valid manifest or is not a valid file - Skipping`);
+      return powercord.api.notices.sendAnnouncement('invalid-theme-manifest', {
+        color: 'orange',
+        message: `Theme "${themeID}" doesn't have a valid manifest or is not a valid file`,
+        button: {
+          text: 'Generate manifest',
+          onClick: () => openExternal(`https://ghostlydilemma.github.io/powercord-manifest-generator/`)
+        }
+      });
     }
 
     this.themes.set(themeID, theme);

--- a/src/Powercord/managers/styles/index.js
+++ b/src/Powercord/managers/styles/index.js
@@ -91,9 +91,9 @@ module.exports = class StyleManager {
             message: `Theme "${themeID}" doesn't have a valid manifest`,
             button: {
               text: 'Generate manifest',
-              onClick: () => openExternal(`https://ghostlydilemma.github.io/powercord-manifest-generator/`)
+              onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator/')
             }
-          })
+          });
         }
 
         if (!window.__OVERLAY__ && manifest.theme) {
@@ -115,7 +115,7 @@ module.exports = class StyleManager {
         message: `Theme "${themeID}" doesn't have a valid manifest or is not a valid file`,
         button: {
           text: 'Generate manifest',
-          onClick: () => openExternal(`https://ghostlydilemma.github.io/powercord-manifest-generator/`)
+          onClick: () => openExternal('https://ghostlydilemma.github.io/powercord-manifest-generator/')
         }
       });
     }


### PR DESCRIPTION
Lets people know easier that they're missing a powercord manifest or that it's incorrect with a link to generate a new one.