### PR TITLE
Update en-GB Discord string

### DIFF
--- a/i18n/overrides/en-GB.json
+++ b/i18n/overrides/en-GB.json
@@ -26,7 +26,7 @@
     "DEVELOPER_APPLICATION_TEST_MODE_AUTHORIZATION_ERROR": "Not authorised to enable test-mode for this application.",
     "DISABLE_INTEGRATION_TWITCH_BODY": "↵Disabling sync will perform the selected expired sub behaviour as if all subs have expired.↵",
     "DISABLE_INTEGRATION_YOUTUBE_BODY": "↵Disabling sync will perform the selected expired membership behaviour as if all members have expired.↵",
-    "FORM_HELP_SERVER_LANGUAGE": "Discord will prioritise this server in search and in recommendations to users who speak the selected language.",
+    "FORM_HELP_SERVER_LANGUAGE": "Discord will prioritise this server in Discovery to users who speak the selected language. Updates sent from Discord in the Moderators-only channel will also be in this language.",
     "FORM_LABEL_MEMBERSHIP_EXPIRE_BEHAVIOR": "Expired Membership Behaviour",
     "FORM_LABEL_ROLES_PRO_TIP_DESCRIPTION": "↵Members use the colour of the highest role they have on this list. Drag roles to reorder them!",
     "FORM_LABEL_ROLE_COLOR": "Role Colour",


### PR DESCRIPTION
Discord has changed the FORM_HELP_SERVER_LANGUAGE string...and so I have updated it in the override