### PR TITLE
More visible GitHub icon.

### DIFF
--- a/src/Powercord/plugins/pc-connections/components/profile/ConnectedAccount.jsx
+++ b/src/Powercord/plugins/pc-connections/components/profile/ConnectedAccount.jsx
@@ -24,7 +24,7 @@ module.exports = class ConnectedAccount extends React.Component {
       <img
         alt={Messages.IMG_ALT_LOGO.format({ name: connection.name })}
         className={classes.connectedAccountIcon}
-        src={connection.icon.color}
+        src={connection.icon.white}
       />
       <div className={classes.connectedAccountNameInner}>
         <div className={classes.connectedAccountName}>{account.name}


### PR DESCRIPTION
As Olykir also mentioned, the icon in the profile modal isn't very visible so the white icon would be better on the black background.