### PR TITLE
Auto-inject based on current Discord instances

### DIFF
--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -17,17 +17,20 @@
  */
 
 const { join } = require('path');
-const { promisify } = require('util');
-const ps = require('ps-node');
-
-const lookup = promisify(ps.lookup);
+const { execSync } = require('child_process');
 
 exports.getAppDir = async () => {
-  const lu = await lookup({
-    command: 'DiscordCanary',
-    arguments: '--type=renderer'
-  });
-  const discordPath = lu[0].command.split('/');
+  const process = execSync('ps x')
+    .toString()
+    .split('\n')
+    .map(s => s.split(' ').filter(Boolean))
+    .find(p => p[4] && p[4].endsWith('DiscordCanary') && p.includes('--type=renderer'));
+
+  if (!process) {
+    return;
+  }
+
+  const discordPath = process[4].split('/');
   discordPath.splice(discordPath.length - 1, 1);
   return join('/', ...discordPath, 'resources', 'app');
 };

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -20,7 +20,7 @@ const { join } = require('path');
 const { execSync } = require('child_process');
 
 exports.getAppDir = async () => {
-  const process = execSync('ps x')
+  const discordProcess = execSync('ps x')
     .toString()
     .split('\n')
     .map(s => s.split(' ').filter(Boolean))
@@ -30,7 +30,7 @@ exports.getAppDir = async () => {
     return;
   }
 
-  const discordPath = process[4].split('/');
+  const discordPath = discordProcess[4].split('/');
   discordPath.splice(discordPath.length - 1, 1);
   return join('/', ...discordPath, 'resources', 'app');
 };

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -26,7 +26,7 @@ exports.getAppDir = async () => {
     .map(s => s.split(' ').filter(Boolean))
     .find(p => p[4] && p[4].endsWith('DiscordCanary') && p.includes('--type=renderer'));
 
-  if (!process) {
+  if (!discordProcess) {
     return;
   }
 

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -16,23 +16,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const { existsSync } = require('fs');
 const { join } = require('path');
+const ps = require('ps-node');
+const Promise = require('bluebird');
 
-const paths = [
-  '/usr/share/discord-canary',
-  '/usr/lib64/discord-canary',
-  '/opt/discord-canary',
-  '/opt/DiscordCanary'
-];
+const lookup = Promise.promisify(ps.lookup);
 
 exports.getAppDir = async () => {
-  const discordPath = paths
-    .find(path => existsSync(path));
-
-  return join(
-    discordPath,
-    'resources',
-    'app'
-  );
+  const lu = await lookup({
+    command: 'DiscordCanary',
+    arguments: '--type=renderer'
+  });
+  const discordPath = lu[0].command.split('/');
+  discordPath.splice(discordPath.length - 1, 1);
+  return join('/', ...discordPath, 'resources', 'app');
 };

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -17,10 +17,10 @@
  */
 
 const { join } = require('path');
+const { promisify } = require('util');
 const ps = require('ps-node');
-const Promise = require('bluebird');
 
-const lookup = Promise.promisify(ps.lookup);
+const lookup = promisify(ps.lookup);
 
 exports.getAppDir = async () => {
   const lu = await lookup({

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/powercord-org/powercord#readme",
   "dependencies": {
-    "bluebird": "^3.7.2",
     "less": "^3.10.3",
     "node-watch": "^0.6.3",
     "ps-node": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   },
   "homepage": "https://github.com/powercord-org/powercord#readme",
   "dependencies": {
+    "bluebird": "^3.7.2",
     "less": "^3.10.3",
     "node-watch": "^0.6.3",
+    "ps-node": "^0.1.6",
     "sass": "^1.23.7",
     "stylus": "^0.54.7",
     "sucrase": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "less": "^3.10.3",
     "node-watch": "^0.6.3",
-    "ps-node": "^0.1.6",
     "sass": "^1.23.7",
     "stylus": "^0.54.7",
     "sucrase": "^3.10.1",


### PR DESCRIPTION
Injection on Linux does not currently support Discord instances running from locations other than those specified in the injection script. This aims to fix that by looking for the location of the currently-running instance of DiscordCanary using the `ps` command and using it as a base for injection.