### PR TITLE
I feel like this would make a little more sense

### DIFF
--- a/src/Powercord/plugins/pc-updater/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-updater/components/Settings.jsx
@@ -426,7 +426,7 @@ module.exports = class UpdaterSettings extends React.Component {
               className='full-column'>Experiments:&#10;{(getExperimentOverrides() && Object.keys(getExperimentOverrides()).join(', ')) || 'n/a'}</div>
             <div className='full-column'>
               Plugins:&#10;{(plugins.length > 1 && `${(this.state.pluginsRevealed ? plugins : plugins.slice(0, 6)).join(', ')}; `) || 'n/a'}
-              {plugins.length > 1 &&
+              {plugins.length > 6 &&
               <Clickable tag='a' onClick={() => this.setState({ pluginsRevealed: !this.state.pluginsRevealed })}>
                 {this.state.pluginsRevealed ? 'Show less' : 'Show more'}
               </Clickable>}


### PR DESCRIPTION
Why have `Show more` display if you don't have more plugins to show, granted its not that import but i just think its a bit funky