### PR TITLE
Add isInjected to the injector

### DIFF
--- a/src/fake_node_modules/powercord/injector/index.js
+++ b/src/fake_node_modules/powercord/injector/index.js
@@ -70,6 +70,14 @@ const injector = {
     injector.injections = injector.injections.filter(i => i.id !== injectionId);
   },
 
+  /**
+   * Check if a function is injected
+   * @param {String} injectionId The injection to check
+   */
+  isInjected: (injectionId) => {
+    return injector.injections.some(i => i.id === injectionId)
+  },
+
   _runPreInjections: (modId, originArgs, _this) => {
     const injections = injector.injections.filter(i => i.module === modId && i.pre);
     if (injections.length === 0) {


### PR DESCRIPTION
Allows plugins to check if something is injected, so that they can avoid spamming the console with "injection id is already used" if they need to reinject but aren't sure if already injected beforehand for whatever reason.

needed since `injections: []` won't update when imported into other modules.