### PR TITLE
Add Discord's Flex component

### DIFF
--- a/src/fake_node_modules/powercord/components/index.js
+++ b/src/fake_node_modules/powercord/components/index.js
@@ -21,6 +21,7 @@ Object.assign(exports, {
   HeaderBar: AsyncComponent.from(getModuleByDisplayName('HeaderBar')),
   TabBar: AsyncComponent.from(getModuleByDisplayName('TabBar')),
   Text: AsyncComponent.from(getModuleByDisplayName('Text')),
+  Flex: AsyncComponent.from(getModuleByDisplayName('Flex')),
   Tooltip: AsyncComponent.from((async () => (await getModule([ 'TooltipContainer' ])).TooltipContainer)()),
   Menu: () => null
 });
@@ -43,6 +44,9 @@ getModuleByDisplayName('TabBar', true, true).then(TabBar => {
 });
 getModuleByDisplayName('Text', true, true).then(Text => {
   [ 'Colors', 'Family', 'Sizes', 'Weights' ].forEach(prop => exports.Text[prop] = Text[prop]);
+});
+getModuleByDisplayName('Flex', true, true).then(Flex => {
+  [ 'Direction', 'Justify', 'Align', 'Wrap', 'Child' ].forEach(prop => exports.Flex[prop] = Flex[prop]);
 });
 getModule([ 'MenuGroup' ]).then(Menu => {
   [ 'MenuCheckboxItem', 'MenuControlItem', 'MenuGroup', 'MenuItem', 'MenuRadioItem', 'MenuSeparator', 'MenuStyle' ]


### PR DESCRIPTION
Add Discord's Flex component to Powercord's exported utility components.

Example usage would be:
```jsx
const { React } = require('powercord/webpack');
const { Flex } = require('powercord/components');

module.exports = class Example extends React.PureComponent {
  render() {
    return (
      <Flex align={Flex.Align.CENTER} justify={Flex.Align.CENTER}>
        <Flex.Child basis='auto'>I'm a flex child!</Flex.Child>
      </Flex>
    );
  }
};
```