### PR TITLE
WIP: Get rid of Electron's remote module

### DIFF
--- a/src/Powercord/apis/keybinds.js
+++ b/src/Powercord/apis/keybinds.js
@@ -1,4 +1,4 @@
-const { remote: { globalShortcut } } = require('electron');
+const globalShortcut = require('powercord/globalShortcut');
 const localShortcut = require('keybindutils/localShortcut');
 const { API } = require('powercord/entities');
 

--- a/src/Powercord/managers/styles.js
+++ b/src/Powercord/managers/styles.js
@@ -215,7 +215,7 @@ module.exports = class StyleManager {
               text: 'Open DevTools',
               color: 'green',
               look: 'ghost',
-              onClick: () => require('electron').remote.BrowserWindow.getFocusedWindow().openDevTools()
+              onClick: () => require('electron').ipcRenderer.invoke('pc-openDevTools')
             },
             {
               text: 'Got it',
@@ -234,7 +234,7 @@ module.exports = class StyleManager {
               text: 'Open DevTools',
               color: 'green',
               look: 'ghost',
-              onClick: () => require('electron').remote.BrowserWindow.getFocusedWindow().openDevTools()
+              onClick: () => require('electron').ipcRenderer.invoke('pc-openDevTools')
             },
             {
               text: 'Got it',

--- a/src/Powercord/plugins/pc-commands/injectAutocomplete.js
+++ b/src/Powercord/plugins/pc-commands/injectAutocomplete.js
@@ -1,4 +1,4 @@
-const { webContents } = require('electron').remote.getCurrentWindow();
+const { ipcRenderer } = require('electron');
 const { React, i18n: { Messages }, typing, getModuleByDisplayName } = require('powercord/webpack');
 const { inject } = require('powercord/injector');
 
@@ -128,7 +128,7 @@ module.exports = async function injectAutocomplete () {
           state = true;
 
           setImmediate(() => {
-            webContents.sendInputEvent({
+            ipcRenderer.invoke('pc-sendInputEvent', {
               type: 'char',
               keyCode: '\u000d'
             });
@@ -139,7 +139,7 @@ module.exports = async function injectAutocomplete () {
           return textValue.split(' ').pop();
         } else if (commands[index].instruction) {
           setImmediate(() => {
-            webContents.sendInputEvent({
+            ipcRenderer.invoke('pc-sendInputEvent', {
               type: 'keyDown',
               keyCode: 'Backspace'
             });

--- a/src/Powercord/plugins/pc-sdk/components/SplashScreen.jsx
+++ b/src/Powercord/plugins/pc-sdk/components/SplashScreen.jsx
@@ -1,6 +1,6 @@
 const { join } = require('path');
 const { format: formatUrl } = require('url');
-const { remote: { BrowserWindow, app: remoteApp }, ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron');
 const { React } = require('powercord/webpack');
 const { Flex, Button } = require('powercord/components');
 

--- a/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
+++ b/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
@@ -1,4 +1,4 @@
-const { remote } = require('electron');
+const { ipcRenderer } = require('electron');
 const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
 const { Icons: { FontAwesome } } = require('powercord/components');
 const { open: openModal, close: closeModal } = require('powercord/modal');
@@ -174,7 +174,7 @@ module.exports = class GeneralSettings extends React.Component {
 
   clearDiscordCache () {
     this.setState({ discordCleared: true });
-    remote.getCurrentWindow().webContents.session.clearCache(() => void 0);
+    ipcRenderer.invoke('pc-clearDiscordCache');
     setTimeout(() => {
       this.setState({ discordCleared: false });
     }, 2500);

--- a/src/Powercord/plugins/pc-utilityClasses/index.js
+++ b/src/Powercord/plugins/pc-utilityClasses/index.js
@@ -1,4 +1,4 @@
-const { remote } = require('electron');
+const { ipcRenderer } = require('electron');
 const { Plugin } = require('powercord/entities');
 const modules = require('./modules');
 
@@ -16,7 +16,7 @@ module.exports = class UtilityClasses extends Plugin {
     if (window.__OVERLAY__) {
       document.body.classList.add('overlay');
     }
-    const webPrefs = remote.getCurrentWebContents().getWebPreferences();
+    const webPrefs = ipcRenderer.sendSync('pc-getWebPreferences');
     if (webPrefs.transparent) {
       document.body.classList.add('transparent');
     }
@@ -28,13 +28,14 @@ module.exports = class UtilityClasses extends Plugin {
       document.body.classList.add('april-fools');
     }
 
-    if (remote.getCurrentWindow().isMaximized()) {
+    if (ipcRenderer.sendSync('pc-getMaximized')) {
       document.body.classList.add('maximized');
     } else {
       document.body.classList.remove('maximized');
     }
-    remote.getCurrentWindow().on('maximize', () => document.body.classList.add('maximized'));
-    remote.getCurrentWindow().on('unmaximize', () => document.body.classList.remove('maximized'));
+    ipcRenderer.send('pc-handleMaximize');
+    ipcRenderer.on('pc-windowMaximize', () => document.body.classList.add('maximized'));
+    ipcRenderer.on('pc-windowUnmaximize', () => document.body.classList.remove('maximized'));
   }
 
   pluginWillUnload () {

--- a/src/fake_node_modules/powercord/globalShortcut.js
+++ b/src/fake_node_modules/powercord/globalShortcut.js
@@ -1,0 +1,40 @@
+const { ipcRenderer } = require('electron');
+/**
+ * An utility class that provides global shortcuts over RPC
+ */
+module.exports = new class GlobalShortcuts {
+  constructor () {
+    this._keybinds = {};
+    ipcRenderer.on('pc-globalShortcutInvoke', (_, accel) => {
+      if (Object.prototype.hasOwnProperty.call(this._keybinds, accel)) {
+        this._keybinds[accel]();
+      }
+    });
+  }
+
+  register (accelerator, callback) {
+    if (!Object.prototype.hasOwnProperty.call(this._keybinds, accelerator)) {
+      this._keybinds[accelerator] = callback;
+      return ipcRenderer.sendSync('pc-registerGlobalShortcut', accelerator);
+    }
+    return false;
+  }
+
+  registerAll (accelerators, callback) {
+    for (const accel of accelerators) {
+      this.register(accel, callback);
+    }
+  }
+
+  unregister (accelerator) {
+    if (Object.prototype.hasOwnProperty.call(this._keybinds, accelerator)) {
+      delete this._keybinds[accelerator];
+      ipcRenderer.invoke('pc-unregisterGlobalShortcut', accelerator);
+    }
+  }
+
+  unregisterAll () {
+    this._keybinds = {};
+    ipcRenderer.invoke('pc-unregisterAllGlobalShortcuts');
+  }
+}();

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -127,6 +127,18 @@ app.once('ready', () => {
 
 // TODO(TTtie): Move this into another module
 ipcMain.on('pc-getPreload', (ev) => ev.returnValue = originalPreload);
+ipcMain.on('pc-getWebPreferences', (ev) => ev.returnValue = ev.sender.getWebPreferences())
+ipcMain.on('pc-getMaximized', (ev) => {
+  const win = BrowserWindow.fromWebContents(ev.sender);
+  if (!win) return;
+  ev.returnValue = win.isMaximized();
+});
+ipcMain.on('pc-handleMaximize', (ev) => {
+  const win = BrowserWindow.fromWebContents(ev.sender);
+  if (!win) return;
+  win.on('maximize', () => ev.reply('pc-windowMaximize'));
+  win.on('unmaximize', () => ev.reply('pc-windowUnmaximize'));
+});
 ipcMain.handle('pc-openDevTools', (ev, isOverlay) => {
   if (isOverlay) {
     ev.sender.openDevTools({ mode: 'detach' });

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -159,6 +159,8 @@ ipcMain.handle('pc-openDevTools', (ev, isOverlay) => {
 ipcMain.handle('pc-sendInputEvent', (ev, data) => {
   ev.sender.sendInputEvent(data);
 });
+ipcMain.handle('pc-clearDiscordCache', (ev) => 
+  new Promise((rs) => ev.sender.session.clearCache(rs)));
 // #endregion IPC
 
 (async () => {

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -126,8 +126,8 @@ app.once('ready', () => {
 // #region IPC
 
 // TODO(TTtie): Move this into another module
-ipcMain.on('getPreload', (ev) => ev.returnValue = originalPreload);
-ipcMain.on('openDevTools', (ev, isOverlay) => {
+ipcMain.on('pc-getPreload', (ev) => ev.returnValue = originalPreload);
+ipcMain.handle('pc-openDevTools', (ev, isOverlay) => {
   if (isOverlay) {
     ev.sender.openDevTools({ mode: 'detach' });
     let devToolsWindow = new BrowserWindow({
@@ -143,6 +143,9 @@ ipcMain.on('openDevTools', (ev, isOverlay) => {
   } else {
     ev.sender.openDevTools();
   }
+});
+ipcMain.handle('pc-sendInputEvent', (ev, data) => {
+  ev.sender.sendInputEvent(data);
 });
 // #endregion IPC
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,7 +18,7 @@ if (process.platform === 'darwin' && !process.env.PATH.includes('/usr/local/bin'
 }
 
 // Discord's preload
-require(ipcRenderer.sendSync('getPreload'));
+require(ipcRenderer.sendSync('pc-getPreload'));
 
 // Debug logging
 let debugLogs;
@@ -78,6 +78,6 @@ try {
 // Overlay devtools
 powercord.once('loaded', () => {
   if (window.__OVERLAY__ && powercord.api.settings.store.getSetting('pc-general', 'openOverlayDevTools', false)) {
-    ipcRenderer.send('openDevTools', true);
+    ipcRenderer.invoke('pc-openDevTools', true);
   }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,6 +1,6 @@
 require('../polyfills');
 
-const { remote } = require('electron');
+const { ipcRenderer } = require('electron');
 const { join } = require('path');
 const { existsSync, mkdirSync, open, write } = require('fs');
 const { LOGS_FOLDER } = require('./fake_node_modules/powercord/constants');
@@ -18,7 +18,7 @@ if (process.platform === 'darwin' && !process.env.PATH.includes('/usr/local/bin'
 }
 
 // Discord's preload
-require(remote.getGlobal('originalPreload'));
+require(ipcRenderer.sendSync("preload"))
 
 // Debug logging
 let debugLogs;
@@ -78,17 +78,6 @@ try {
 // Overlay devtools
 powercord.once('loaded', () => {
   if (window.__OVERLAY__ && powercord.api.settings.store.getSetting('pc-general', 'openOverlayDevTools', false)) {
-    const overlayWindow = remote.getCurrentWindow();
-    overlayWindow.openDevTools({ mode: 'detach' });
-    let devToolsWindow = new remote.BrowserWindow({
-      webContents: overlayWindow.devToolsWebContents
-    });
-    devToolsWindow.on('ready-to-show', () => {
-      devToolsWindow.show();
-    });
-    devToolsWindow.on('close', () => {
-      overlayWindow.closeDevTools();
-      devToolsWindow = null;
-    });
+    ipcRenderer.invoke('openDevTools', true);
   }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,7 +18,7 @@ if (process.platform === 'darwin' && !process.env.PATH.includes('/usr/local/bin'
 }
 
 // Discord's preload
-require(ipcRenderer.sendSync("preload"))
+require(ipcRenderer.sendSync('getPreload'));
 
 // Debug logging
 let debugLogs;
@@ -78,6 +78,6 @@ try {
 // Overlay devtools
 powercord.once('loaded', () => {
   if (window.__OVERLAY__ && powercord.api.settings.store.getSetting('pc-general', 'openOverlayDevTools', false)) {
-    ipcRenderer.invoke('openDevTools', true);
+    ipcRenderer.send('openDevTools', true);
   }
 });


### PR DESCRIPTION
This PR removes all the code related to the `remote` function of Electron, as described in #337 
Closes #337 
**To do**:
- [ ] Main process injection
- [ ] A simple to use API to create browser windows
- [ ] Split the IPC code into a separate module