### PR TITLE
Update pc-reactdevtools

### DIFF
--- a/src/Powercord/plugins/pc-reactdevtools/index.js
+++ b/src/Powercord/plugins/pc-reactdevtools/index.js
@@ -1,104 +1,104 @@
-const { join } = require("path");
-const { remote } = require("electron");
+const { join } = require('path');
+const { remote } = require('electron');
 const {
-	createWriteStream,
-	existsSync,
-	readFileSync,
-	unlinkSync,
-} = require("fs");
-const { Plugin } = require("powercord/entities");
-const { get } = require("powercord/http");
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  unlinkSync
+} = require('fs');
+const { Plugin } = require('powercord/entities');
+const { get } = require('powercord/http');
 
-const unzip = require("unzip-crx");
+const unzip = require('unzip-crx');
 
-const crxPath = join(__dirname, "rdt.crx");
-const devtoolsPath = join(__dirname, "react-dev-tools");
+const crxPath = join(__dirname, 'rdt.crx');
+const devtoolsPath = join(__dirname, 'react-dev-tools');
 
 // @todo: Throw this plugin away and use a better loading method
 module.exports = class ReactDevtools extends Plugin {
-	get isInstalledLocally() {
-		return existsSync(crxPath);
-	}
+  get isInstalledLocally () {
+    return existsSync(crxPath);
+  }
 
-	startPlugin() {
-		if (!this.isInstalledLocally) {
-			this.download();
-		}
+  startPlugin () {
+    if (!this.isInstalledLocally) {
+      this.download();
+    }
 
-		this.checkForUpdate();
+    this.checkForUpdate();
 
-		this.addReactDevTools();
-	}
+    this.addReactDevTools();
+  }
 
-	pluginWillUnload() {
-		this.removeReactDevTools();
-	}
+  pluginWillUnload () {
+    this.removeReactDevTools();
+  }
 
-	addReactDevTools() {
-		this.removeReactDevTools();
+  addReactDevTools () {
+    this.removeReactDevTools();
 
-		if (this.isInstalledLocally) {
-			remote.BrowserWindow.addDevToolsExtension(devtoolsPath)
-				.then(() => {
-					this.log(`Successfully installed React DevTools.
+    if (this.isInstalledLocally) {
+      remote.BrowserWindow.addDevToolsExtension(devtoolsPath)
+        .then(() => {
+          this.log(`Successfully installed React DevTools.
 If React DevTools is missing or empty, close Developer Tools and re-open it.
 If you are still unable to find tabs for React DevTools in Developer Tools, reload your client (Ctrl + R)."`);
-				})
-				.catch((e) => {
-					this.error(
-						"Couldn't find React DevTools in Chrome extensions!"
-					);
-				});
-		}
-	}
+        })
+        .catch((e) => {
+          this.error("Couldn't find React DevTools in Chrome extensions!");
+        });
+    }
+  }
 
-	removeReactDevTools() {
-		remote.BrowserWindow.removeDevToolsExtension("React Developer Tools");
-	}
+  removeReactDevTools () {
+    remote.BrowserWindow.removeDevToolsExtension('React Developer Tools');
+  }
 
-	checkForUpdate() {
-		const local = readFileSync(crxPath);
-		const crxLink =
-			"https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc";
-		return get(crxLink).then(
-			(res) => {
-				if (res.body !== local) {
-					this.download();
-				}
-			},
-			(err) => this.error(err)
-		);
-	}
+  checkForUpdate () {
+    const local = readFileSync(crxPath);
+    const crxLink =
+      'https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc';
+    return get(crxLink).then(
+      (res) => {
+        if (res.body !== local) {
+          this.download();
+        }
+      },
+      (err) => this.error(err)
+    );
+  }
 
-	download() {
-		const crxLink =
-			"https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc";
-		return get(crxLink).then(
-			(res) =>
-				get(res.headers.location).then(
-					(resp) => {
-						const crxFile = createWriteStream(crxPath);
-						crxFile.write(resp.body, (err) => {
-							if (err) {
-								this.error(err);
-							}
+  download () {
+    const crxLink =
+      'https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc';
+    return get(crxLink).then(
+      (res) =>
+        get(res.headers.location).then(
+          (resp) => {
+            const crxFile = createWriteStream(crxPath);
+            crxFile.write(resp.body, (err) => {
+              if (err) {
+                this.error(err);
+              }
 
-							// Finish writing to the file and close it before trying to unzip it.
-							crxFile.close();
+              // Finish writing to the file and close it before trying to unzip it.
+              crxFile.close();
 
-							try {
-								// Purge the current folder if it already exists.
-								unlinkSync(devtoolsPath);
-							} catch (e) {}
-							// Unzip the folder.
-							unzip(crxPath, devtoolsPath).then(() => {
-								this.addReactDevTools();
-							});
-						});
-					},
-					(err) => this.error(err)
-				),
-			(err) => this.error(err)
-		);
-	}
+              try {
+                // Purge the current folder if it already exists.
+                unlinkSync(devtoolsPath);
+              } catch (e) {
+                this.error(e);
+              }
+              // Unzip the folder.
+              unzip(crxPath, devtoolsPath).then(() => {
+                this.addReactDevTools();
+              });
+            });
+          },
+          (err) => this.error(err)
+        ),
+      (err) => this.error(err)
+    );
+  }
 };

--- a/src/Powercord/plugins/pc-reactdevtools/index.js
+++ b/src/Powercord/plugins/pc-reactdevtools/index.js
@@ -93,8 +93,6 @@ If you are still unable to find tabs for React DevTools in Developer Tools, relo
 							// Unzip the folder.
 							unzip(crxPath, devtoolsPath).then(() => {
 								this.addReactDevTools();
-								// Remove the CRX to free space.
-								unlinkSync(crxPath);
 							});
 						});
 					},

--- a/src/Powercord/plugins/pc-reactdevtools/index.js
+++ b/src/Powercord/plugins/pc-reactdevtools/index.js
@@ -1,84 +1,106 @@
-const { join } = require('path');
-const { remote } = require('electron');
-const { createWriteStream, existsSync, readFileSync } = require('fs');
-const { Plugin } = require('powercord/entities');
-const { get } = require('powercord/http');
+const { join } = require("path");
+const { remote } = require("electron");
+const {
+	createWriteStream,
+	existsSync,
+	readFileSync,
+	unlinkSync,
+} = require("fs");
+const { Plugin } = require("powercord/entities");
+const { get } = require("powercord/http");
 
-const unzip = require('unzip-crx');
+const unzip = require("unzip-crx");
+
+const crxPath = join(__dirname, "rdt.crx");
+const devtoolsPath = join(__dirname, "react-dev-tools");
 
 // @todo: Throw this plugin away and use a better loading method
 module.exports = class ReactDevtools extends Plugin {
-  get path () {
-    return join(__dirname, 'rdt.crx');
-  }
+	get isInstalledLocally() {
+		return existsSync(crxPath);
+	}
 
-  get folderPath () {
-    return join(__dirname, 'react-dev-tools');
-  }
+	startPlugin() {
+		if (!this.isInstalledLocally) {
+			this.download();
+		}
 
-  get isInstalledLocally () {
-    return existsSync(this.path);
-  }
+		this.checkForUpdate();
 
-  startPlugin () {
-    // eslint-disable-next-line no-unreachable
-    this.listener = this.listener.bind(this);
-    if (!this.isInstalledLocally) {
-      this.download();
-    }
+		this.addReactDevTools();
+	}
 
-    this.checkForUpdate();
+	pluginWillUnload() {
+		this.removeReactDevTools();
+	}
 
-    remote.getCurrentWindow().webContents.on('devtools-opened', this.listener);
-    if (remote.getCurrentWindow().webContents.isDevToolsOpened()) {
-      this.listener();
-    }
-  }
+	addReactDevTools() {
+		this.removeReactDevTools();
 
-  pluginWillUnload () {
-    remote
-      .getCurrentWindow()
-      .webContents.removeListener('devtools-opened', this.listener);
-  }
+		if (this.isInstalledLocally) {
+			remote.BrowserWindow.addDevToolsExtension(devtoolsPath)
+				.then(() => {
+					this.log(`Successfully installed React DevTools.
+If React DevTools is missing or empty, close Developer Tools and re-open it.
+If you are still unable to find tabs for React DevTools in Developer Tools, reload your client (Ctrl + R)."`);
+				})
+				.catch((e) => {
+					this.error(
+						"Couldn't find React DevTools in Chrome extensions!"
+					);
+				});
+		}
+	}
 
-  listener () {
-    remote.BrowserWindow.removeDevToolsExtension('React Developer Tools');
+	removeReactDevTools() {
+		remote.BrowserWindow.removeDevToolsExtension("React Developer Tools");
+	}
 
-    if (this.isInstalledLocally) {
-      if (remote.BrowserWindow.addDevToolsExtension(this.folderPath)) {
-        this.log('Successfully installed React DevTools.');
-        this.log('If React DevTools is missing or empty, close Developer Tools and re-open it.');
-      } else {
-        this.error('Couldn\'t find React DevTools in Chrome extensions!');
-      }
-    }
-  }
+	checkForUpdate() {
+		const local = readFileSync(crxPath);
+		const crxLink =
+			"https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc";
+		return get(crxLink).then(
+			(res) => {
+				if (res.body !== local) {
+					this.download();
+				}
+			},
+			(err) => this.error(err)
+		);
+	}
 
-  checkForUpdate () {
-    const local = readFileSync(this.path);
-    const crxLink = 'https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc';
-    return get(crxLink).then(res => {
-      if (res.body !== local) {
-        this.download();
-      }
-    }, err => this.error(err));
-  }
+	download() {
+		const crxLink =
+			"https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc";
+		return get(crxLink).then(
+			(res) =>
+				get(res.headers.location).then(
+					(resp) => {
+						const crxFile = createWriteStream(crxPath);
+						crxFile.write(resp.body, (err) => {
+							if (err) {
+								this.error(err);
+							}
 
-  download () {
-    const crxLink = 'https://clients2.google.com/service/update2/crx?response=redirect&os=win&arch=x86-64&os_arch=x86-64&nacl_arch=x86-64&prod=chromecrx&prodchannel=unknown&prodversion=77.0.3865.90&acceptformat=crx2&x=id=fmkadmapgofadopljbjfkapdkoienihi%26uc';
-    return get(crxLink).then(res => get(res.headers.location).then(resp => {
-      const crxFile = createWriteStream(this.path);
-      crxFile.write(resp.body, err => {
-        if (err) {
-          this.error(err);
-        }
-        return crxFile.close();
-      });
+							// Finish writing to the file and close it before trying to unzip it.
+							crxFile.close();
 
-      unzip(this.path, this.folderPath).then(() => {
-        this.listener();
-        this.log('If you are still unable to find tabs for React DevTools in Developer Tools, reload your client (Ctrl + R).');
-      });
-    }, err => this.error(err)), err => this.error(err));
-  }
+							try {
+								// Purge the current folder if it already exists.
+								unlinkSync(devtoolsPath);
+							} catch (e) {}
+							// Unzip the folder.
+							unzip(crxPath, devtoolsPath).then(() => {
+								this.addReactDevTools();
+								// Remove the CRX to free space.
+								unlinkSync(crxPath);
+							});
+						});
+					},
+					(err) => this.error(err)
+				),
+			(err) => this.error(err)
+		);
+	}
 };

--- a/src/Powercord/plugins/pc-reactdevtools/index.js
+++ b/src/Powercord/plugins/pc-reactdevtools/index.js
@@ -44,8 +44,8 @@ module.exports = class ReactDevtools extends Plugin {
 If React DevTools is missing or empty, close Developer Tools and re-open it.
 If you are still unable to find tabs for React DevTools in Developer Tools, reload your client (Ctrl + R)."`);
         })
-        .catch((e) => {
-          this.error("Couldn't find React DevTools in Chrome extensions!");
+        .catch(() => {
+          this.error('Couldn\'t find React DevTools in Chrome extensions!');
         });
     }
   }

--- a/src/Powercord/plugins/pc-reactdevtools/manifest.json
+++ b/src/Powercord/plugins/pc-reactdevtools/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "React Devtools",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Adds React Devtools in Discord devtools",
   "author": "Powercord Team",
   "license": "MIT",


### PR DESCRIPTION
It's still a temporary fix considering [this](https://github.com/KyzaGitHub/powercord/blob/2311b3fb83522d11e266a818701bbba15493734b/src/Powercord/plugins/pc-reactdevtools/index.js#L17), but it fixes a several problems with the plugin.

- [x] Actually waits for the CRX to finish downloading before unzipping it.
  - *sigh*
- [x] Doesn't re-add the devtools extension every single time the devtools are opened.
  - That caused problems and made it harder to get the React Devtools tabs to even show up in the first place.
- [x] Uses a promise for the check on whether adding the extension failed or not instead of an `if` statement.
- [x] Purges the React Devtools folder before unzipping the CRX.
  - I'm not *exactly* sure how [`unzip-crx`](https://github.com/peerigon/unzip-crx) works, but this could prevent some--maybe unlikely but still possible--future problems.
- [x] ~~Cleans up the temporary CRX file when it's finished unzipping it.~~

I wasn't sure about the reason for [`path`](https://github.com/powercord-org/powercord/blob/f8180d3ca86f027f4d3102b3b34c3f774239d1a9/src/Powercord/plugins/pc-reactdevtools/index.js#L11) and [`folderPath`](https://github.com/powercord-org/powercord/blob/f8180d3ca86f027f4d3102b3b34c3f774239d1a9/src/Powercord/plugins/pc-reactdevtools/index.js#L15) not being constant variables, so I moved them outside of the plugin.
