### PR TITLE
fix open plugins/themes folder buttons

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/components/manage/Base.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/manage/Base.jsx
@@ -91,7 +91,7 @@ class Base extends React.Component {
           {
             type: 'button',
             name: Messages[`POWERCORD_${this.state.key}_OPEN_FOLDER`],
-            onClick: () => shell.openItem(join(__dirname, '..', '..', '..', '..', this.constructor.name.toLowerCase()))
+            onClick: () => shell.openPath(join(__dirname, '..', '..', '..', '..', this.constructor.name.toLowerCase()))
           },
           {
             type: 'button',


### PR DESCRIPTION
Newbies don't know where are located those folders so it should be useful.