### PR TITLE
Sudo warning for Linux

### DIFF
--- a/injectors/index.js
+++ b/injectors/index.js
@@ -37,4 +37,10 @@ try {
     console.log(`Unsupported argument "${process.argv[2]}", exiting..`);
     process.exit(1);
   }
-})().catch(e => console.error('fucky wucky', e));
+})().catch(e => {
+  if (e.code === 'EACCES' && process.platform === 'linux') {
+    console.log('Missing required permissions, rerun with root privileges.');
+  } else {
+    console.error('fucky wucky', e)
+  }
+});

--- a/injectors/index.js
+++ b/injectors/index.js
@@ -39,7 +39,7 @@ try {
   }
 })().catch(e => {
   if (e.code === 'EACCES') {
-    console.log(`Unable to ${process.argv[2]} because of missing permissions. Consider rerunning with elevated rights. `);
+    console.log(`Unable to ${process.argv[2]} because of missing permissions. Consider rerunning with elevated rights.`);
   } else {
     console.error('fucky wucky', e)
   }

--- a/injectors/index.js
+++ b/injectors/index.js
@@ -38,8 +38,8 @@ try {
     process.exit(1);
   }
 })().catch(e => {
-  if (e.code === 'EACCES' && process.platform === 'linux') {
-    console.log('Missing required permissions, rerun with root privileges.');
+  if (e.code === 'EACCES') {
+    console.log(`Unable to ${process.argv[2]} because of missing permissions. Consider rerunning with elevated rights. `);
   } else {
     console.error('fucky wucky', e)
   }


### PR DESCRIPTION
When running the injector without root privileges under Linux, it will throw an EACCES error.

This simple change tells the users to run as sudo instead of throwing the error at them.
