### PR TITLE
Prompt for custom install path 

### DIFF
--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -1,6 +1,9 @@
 const { join } = require('path');
 const { existsSync } = require('fs');
 const { execSync } = require('child_process');
+const readline = require('readline');
+
+
 
 exports.getAppDir = async () => {
   const discordProcess = execSync('ps x')
@@ -17,7 +20,27 @@ exports.getAppDir = async () => {
       '/opt/discord-canary',
       '/opt/DiscordCanary'
     ];
-    const discordPath = paths.find(path => existsSync(path));
+    let discordPath = paths.find(path => existsSync(path));
+
+    if (discordPath === undefined) {
+      const readlineInterface = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
+
+      console.log('A Discord Canary installation sdcould not be found at the usual paths.')
+       discordPath = await new Promise(resolve => readlineInterface.question('Provide your Discord Canary install location: ', customDiscordPath => {
+        if (existsSync(customDiscordPath)) {
+          readlineInterface.close();
+          resolve(customDiscordPath);
+        } else {
+          console.log('Path provided is invalid.');
+          process.exit(1);
+        }
+        
+      }));
+    }
+
     return join(discordPath, 'resources', 'app');
   }
 

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -3,8 +3,6 @@ const { existsSync } = require('fs');
 const { execSync } = require('child_process');
 const readline = require('readline');
 
-
-
 exports.getAppDir = async () => {
   const discordProcess = execSync('ps x')
     .toString()

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -28,13 +28,13 @@ exports.getAppDir = async () => {
         output: process.stdout
       });
 
-      console.log('A Discord Canary installation sdcould not be found at the usual paths.')
+      console.log('A Discord Canary installation could not be found at the usual paths.')
        discordPath = await new Promise(resolve => readlineInterface.question('Provide your Discord Canary install location: ', customDiscordPath => {
         if (existsSync(customDiscordPath)) {
           readlineInterface.close();
           resolve(customDiscordPath);
         } else {
-          console.log('Path provided is invalid.');
+          console.log('Path provided is invalid, aborting.');
           process.exit(1);
         }
         


### PR DESCRIPTION
While both Windows and macOS have standard/consistent install locations for the Discord Canary client, Linux doesn't. The script that gets the install path for Linux looks through common paths but If the user doesn't have it installed in those locations then it returns `undefined` and errors (see #352).

This change checks if the path is `undefined` and if it is, it prompts the user to enter the path of their actual install location.

Not sure if asking for input here is right but if not I can just remove that bit. 

