### PR TITLE
Added unsupported plugin warning

### DIFF
--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -37,32 +37,33 @@ module.exports = class PluginManager {
         dependencies: [],
         optionalDependencies: []
       }, require(resolve(this.pluginDir, pluginID, 'manifest.json')));
-      if (!pluginID.startsWith("pc-"))
+      if (!pluginID.startsWith("pc-")) {
         if (!(existsSync(resolve(this.pluginDir, pluginID, '.git')) || existsSync(resolve(this.pluginDir, pluginID, '.ignore-no-git')))) {
-          powercord.api.notices.sendToast('pc-plugin-warning-' + pluginID, {
+          powercord.api.notices.sendToast(`pc-plugin-warning-${pluginID}`, {
             header: 'Plugin warning', // required
-            content: 'Plugin "' + pluginID + '" is installed incorrectly, or is unsupported!',
+            content: `Plugin "${pluginID}" is installed incorrectly, or is unsupported!`,
             image: 'https://cdn.discordapp.com/emojis/540635231217123338.png?v=1',
             imageClass: 'powercord_warning_icon',
             type: 'info',
             timeout: 10e3,
-            buttons: [{
+            buttons: [ {
               text: 'How do I fix it?', // required
               color: 'green',
               size: 'medium',
               look: 'outlined',
-              onClick: () => shell.openExternal("https://www.youtube.com/watch?v=7jdl7nlZ664")
+              onClick: () => shell.openExternal('https://www.youtube.com/watch?v=7jdl7nlZ664')
             },
             {
               text: 'Ignore permanently', // required
               color: 'red',
               size: 'medium',
               look: 'outlined',
-              onClick: () => writeFileSync(resolve(this.pluginDir, pluginID, '.ignore-no-git'), "Remove this file if your plugin is a valid git repo!")
-            }],
+              onClick: () => writeFileSync(resolve(this.pluginDir, pluginID, '.ignore-no-git'), 'Remove this file if your plugin is a valid git repo!')
+            } ],
             callback: () => console.log('Plugin warning ignored')
           });
         }
+      }
     } catch (e) {
       return console.error('%c[Powercord]', 'color: #7289da', `Plugin ${pluginID} doesn't have a valid manifest - Skipping`);
     }
@@ -100,7 +101,7 @@ module.exports = class PluginManager {
     } catch (e) {
       // chhhh
     }
-    this.mount (pluginID);
+    this.mount(pluginID);
     this.plugins.get(pluginID)._load();
   }
 
@@ -194,7 +195,7 @@ module.exports = class PluginManager {
     const missingPlugins = [];
     const isOverlay = (/overlay/).test(location.pathname);
     readdirSync(this.pluginDir).sort(this._sortPlugins).forEach(filename => !this.isInstalled(filename) && this.mount(filename));
-    for (const plugin of [...this.plugins.values()]) {
+    for (const plugin of [ ...this.plugins.values() ]) {
       if (powercord.settings.get('disabledPlugins', []).includes(plugin.entityID)) {
         continue;
       }

--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -1,6 +1,7 @@
 const { resolve } = require('path');
 const { readdirSync, existsSync, writeFileSync } = require('fs');
 const { rmdirRf } = require('powercord/util');
+const shell = require('electron').shell;
 
 module.exports = class PluginManager {
   constructor () {
@@ -50,7 +51,7 @@ module.exports = class PluginManager {
               color: 'green',
               size: 'medium',
               look: 'outlined',
-              onClick: () => window.location.href = "https://canary.discordapp.com/channels/538759280057122817/539443125727395858/582984735337218058"
+              onClick: () => shell.openExternal("https://www.youtube.com/watch?v=7jdl7nlZ664")
             },
             {
               text: 'Ignore permanently', // required

--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -1,7 +1,7 @@
 const { resolve } = require('path');
 const { readdirSync, existsSync, writeFileSync } = require('fs');
 const { rmdirRf } = require('powercord/util');
-const shell = require('electron').shell;
+const { shell } = require('electron');
 
 module.exports = class PluginManager {
   constructor () {
@@ -37,7 +37,7 @@ module.exports = class PluginManager {
         dependencies: [],
         optionalDependencies: []
       }, require(resolve(this.pluginDir, pluginID, 'manifest.json')));
-      if (!pluginID.startsWith("pc-")) {
+      if (!pluginID.startsWith('pc-')) {
         if (!(existsSync(resolve(this.pluginDir, pluginID, '.git')) || existsSync(resolve(this.pluginDir, pluginID, '.ignore-no-git')))) {
           powercord.api.notices.sendToast(`pc-plugin-warning-${pluginID}`, {
             header: 'Plugin warning', // required


### PR DESCRIPTION
Detects wether a .git folder exists, or a .ignore-no-git file (generated by the Ignore button)
Has a button to create a file so the warning doesn't show up in the client
I hope that hereby we can assist users that use the Github download button without them needing to ask for support