### PR TITLE
Switch from system-font-families to font-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "dependencies": {
     "codemirror": "^5.54.0",
+    "font-list": "^1.2.11",
     "less": "^3.11.1",
     "node-watch": "^0.6.4",
     "sass": "^1.26.7",
     "stylus": "^0.54.7",
     "sucrase": "^3.15.0",
-    "system-font-families": "^0.4.1",
     "unzip-crx": "^0.2.0"
   },
   "devDependencies": {

--- a/src/Powercord/plugins/pc-moduleManager/components/manage/ThemeField.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/manage/ThemeField.jsx
@@ -1,14 +1,16 @@
 /* eslint-disable */
-const { default: SystemFonts } = require('system-font-families');
+const fontList = require('font-list');
 const { React, Flux, getModule, getModuleByDisplayName, i18n: { Messages } } = require('powercord/webpack');
 const { TextInput, SwitchItem, ButtonItem, SelectInput, ColorPickerInput } = require('powercord/components/settings');
 const { TabBar, Divider, Button, AsyncComponent } = require('powercord/components');
 
 const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/ig;
 
-let fonts = null
-const systemFonts = new SystemFonts();
-const fontsPromise = systemFonts.getFonts().then(f => (fonts = f))
+let fonts = null;
+const fontsPromise = fontList.getFonts().then(f => {
+  const cleaned = f.map(font => font.replace(/["\\]/g, '')); // Removes double quotes and backslashes
+  return fonts = cleaned;
+});
 
 class ThemeField extends React.PureComponent {
   constructor (props) {
@@ -23,7 +25,7 @@ class ThemeField extends React.PureComponent {
   componentDidMount () {
     if (this.props.option.type === 'font' && !this.state.fonts) {
       fontsPromise.then(fonts => {
-        this.setState({ fonts })
+        this.setState({ fonts });
       })
     }
   }


### PR DESCRIPTION
`system-font-families` depends on `ttfinfo` which has been unmaintained for over 7 years.

`ttfinfo` loads into memory **all** the content of **every** font file present on a system, even though Powercord (to my knowledge) only uses the font names. This can cause huge startup memory consumption depending on the total filesize of the system's installed fonts.

This PR attempts to fix this by switching from `system-font-families` to `font-list`. `font-list` takes a different approach by calling the command `fc-list` provided by `fontconfig`. The two packages do produce different results. `font-list` outputs less fonts, but the missing fonts are usually some variants of a parent font.

[This file](https://github.com/powercord-org/powercord/files/5146384/system-fonts.txt) lists the fonts installed on my Arch Linux system.
These are text files containing the results each package produced on my personal machine.
[font-list.txt](https://github.com/powercord-org/powercord/files/5146381/font-list.txt)
[system-font-families.txt](https://github.com/powercord-org/powercord/files/5146382/system-font-families.txt)

Note that what I have said above about mainly targets Linux. I have not tested this on a Windows or macOS system and do not know of this PR's effectiveness on said systems; however, I believe it shouldn't be causing any huge regressions.