### PR TITLE
prevent updater crashes when commits[0] is undefined

### DIFF
--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -92,7 +92,7 @@ module.exports = class Updater extends Plugin {
           const shouldUpdate = await entity._checkForUpdates();
           if (shouldUpdate) {
             const commits = await entity._getUpdateCommits();
-            if (skipped[entity.updateIdentifier] === commits[0].id) {
+            if (commits[0] && skipped[entity.updateIdentifier] === commits[0].id) {
               return;
             }
             updates.push({


### PR DESCRIPTION
prevent the rare case of the updater getting stuck on the last item