### PR TITLE
MacOS: Allowed Specifying Install Location

### DIFF
--- a/injectors/darwin.js
+++ b/injectors/darwin.js
@@ -3,5 +3,10 @@
  * All Rights Reserved. Licensed under the Porkord License
  * https://powercord.dev/porkord-license
  */
-
-exports.getAppDir = async () => '/Applications/Discord Canary.app/Contents/Resources/app';
+if (process.argv.includes('--install-path')) {
+  installPath = process.argv[process.argv.indexOf('--install-path') + 1]
+  console.log('\x1b[35m%s\x1b[0m', 'Installing to ' + installPath)
+  exports.getAppDir = async () => installPath + '/Contents/Resources/app'
+} else {
+  exports.getAppDir = async () => '/Applications/Discord Canary.app/Contents/Resources/app';
+}

--- a/injectors/darwin.js
+++ b/injectors/darwin.js
@@ -3,10 +3,11 @@
  * All Rights Reserved. Licensed under the Porkord License
  * https://powercord.dev/porkord-license
  */
+const path = require('path');
 if (process.argv.includes('--install-path')) {
   installPath = process.argv[process.argv.indexOf('--install-path') + 1]
   console.log('\x1b[35m%s\x1b[0m', 'Installing to ' + installPath)
-  exports.getAppDir = async () => installPath + '/Contents/Resources/app'
+  exports.getAppDir = async () => path.join(installPath, 'Contents/Resources/app')
 } else {
   exports.getAppDir = async () => '/Applications/Discord Canary.app/Contents/Resources/app';
 }


### PR DESCRIPTION
This allows specifying a custom installation location for discord on MacOS. Many prefer to install to a local location, like `~/Applications/Discord Canary.app`.  You can use a command-line argument to specify where your discord app is located, allowing you to do `npm run plug -- --install-path "/Users/example/Applications/Discord Canary.app"` (note the extra `--` as we are using npm).