### PR TITLE
Handle error while creating app directory

### DIFF
--- a/injectors/main.js
+++ b/injectors/main.js
@@ -23,7 +23,14 @@ exports.inject = async ({ getAppDir }) => {
     return false;
   }
 
-  await mkdir(appDir);
+  try {
+    await mkdir(appDir);
+  } catch (err) {
+    console.log('Your Discord Canary install appears to be broken.', '\n');
+    console.log(`${AnsiEscapes.YELLOW}NOTE:${AnsiEscapes.RESET} This issue has been known to happen using non-official Discord Canary installs. Try using the official installation method if you're not already.`);
+
+    return false;
+  }
   await Promise.all([
     writeFile(
       join(appDir, 'index.js'),


### PR DESCRIPTION
I had an issue injecting Powercord into [the `discord-canary-electron-bin` AUR package](https://aur.archlinux.org/packages/discord-canary-electron-bin/). After some troubleshooting, I found that the problem was a discrepancy in the way that this specific package installed Discord Canary.

This adds a check which informs the user that their Discord install is unusual.