### PR TITLE
Fix not re-adding injected function's props

### DIFF
--- a/src/fake_node_modules/powercord/injector/index.js
+++ b/src/fake_node_modules/powercord/injector/index.js
@@ -25,6 +25,8 @@ const injector = {
       const id = randomBytes(16).toString('hex');
       mod.__powercordInjectionId = Object.assign((mod.__powercordInjectionId || {}), { [funcName]: id });
       mod[`__powercordOriginal_${funcName}`] = mod[funcName]; // To allow easier debugging
+      const props = { ...mod[funcName] };
+      const copy = { ...mod }[funcName];
       mod[funcName] = (_oldMethod => function (...args) {
         const finalArgs = injector._runPreInjections(id, args, this);
         if (finalArgs !== false && Array.isArray(finalArgs)) {
@@ -32,6 +34,8 @@ const injector = {
           return injector._runInjections(id, finalArgs, returned, this);
         }
       })(mod[funcName]);
+      Object.assign(mod[funcName], props);
+      mod[funcName].toString = () => copy.toString();
 
       injector.injections[id] = [];
     }

--- a/src/fake_node_modules/powercord/injector/index.js
+++ b/src/fake_node_modules/powercord/injector/index.js
@@ -25,8 +25,7 @@ const injector = {
       const id = randomBytes(16).toString('hex');
       mod.__powercordInjectionId = Object.assign((mod.__powercordInjectionId || {}), { [funcName]: id });
       mod[`__powercordOriginal_${funcName}`] = mod[funcName]; // To allow easier debugging
-      const props = { ...mod[funcName] };
-      const copy = { ...mod }[funcName];
+      const funcCopy = { ...mod }[funcName];
       mod[funcName] = (_oldMethod => function (...args) {
         const finalArgs = injector._runPreInjections(id, args, this);
         if (finalArgs !== false && Array.isArray(finalArgs)) {
@@ -34,8 +33,8 @@ const injector = {
           return injector._runInjections(id, finalArgs, returned, this);
         }
       })(mod[funcName]);
-      Object.assign(mod[funcName], props);
-      mod[funcName].toString = () => copy.toString();
+      Object.assign(mod[funcName], funcCopy);
+      mod[funcName].toString = () => funcCopy.toString();
 
       injector.injections[id] = [];
     }


### PR DESCRIPTION
You're free. No more forgetting to re-add the `displayName` to your injected React components.

An automatic pull bot that I thought I configured for only a specific repository tried to sabotage Powercord by deleting my commits. I dealt with that.