### PR TITLE
Escape path when injecting

### DIFF
--- a/injectors/main.js
+++ b/injectors/main.js
@@ -27,7 +27,10 @@ exports.inject = async ({ getAppDir }) => {
   await Promise.all([
     writeFile(
       join(appDir, 'index.js'),
-      `require(\`${__dirname.replace(RegExp(sep.repeat(2), 'g'), '/')}/../src/patcher.js\`)`
+      `require('${__dirname
+        .replace(RegExp(sep.repeat(2), 'g'), '/')
+        .replaceAll('\\', '\\\\')
+        .replaceAll('\'', '\\\'')}/../src/patcher.js')`
     ),
     writeFile(
       join(appDir, 'package.json'),


### PR DESCRIPTION
A better way to do #26 IMHO.
#26 allows `'` in path, but disallows \` and `${`. This PR allows all of them and `\` by escaping `'` and `\`. 
Should not break Windows compatibility since the escaping is made after the separator replacement, but needs some testing. 