### PR TITLE
Fixed settings path and added window frame option

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -89,6 +89,8 @@
   "POWERCORD_SETTINGS_TRANSPARENT": "Transparent Window",
   "POWERCORD_SETTINGS_TRANSPARENT_DESC": "Makes any windows opened by Discord transparent, useful for theming.\n****WARNING:**** This will break **window snapping** on Windows. **Hardware acceleration** must be turned **off** on Linux. You may encounter issues and have black background in some cases, like when the window is cut off at the top, or the bottom due to monitor resolution or when devtools are open and docked. **Requires restart**.",
   "POWERCORD_SETTINGS_TRANSPARENT_GLASSCORD": "It looks like you have Glasscord installed, which means you can't update this setting directly within Powercord. Learn more about configuring Glasscord [here]({glasscordCfgUrl})",
+  "POWERCORD_SETTINGS_FRAME": "Window Frame",
+  "POWERCORD_SETTINGS_FRAME_DESC": "Shows a frame around the Discord window which contains the minimize, maximize and close buttons. Disable this option to remove the frame.",
   "POWERCORD_SNIPPET_APPLIED": "Snippet Applied",
   "POWERCORD_SNIPPET_APPLY": "Apply Snippet",
   "POWERCORD_SNIPPET_LINE1": "Snippet from #css-snippets applied the {date, date, medium} at {date, time, medium}",

--- a/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
+++ b/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
@@ -98,6 +98,16 @@ module.exports = class GeneralSettings extends React.Component {
             {Messages.POWERCORD_SETTINGS_TRANSPARENT}
           </SwitchItem>
           <SwitchItem
+            note={Messages.POWERCORD_SETTINGS_FRAME_DESC}
+            value={getSetting('windowFrame', true)}
+            onChange={() => {
+              toggleSetting('windowFrame');
+              this.askRestart();
+            }}
+          >
+            {Messages.POWERCORD_SETTINGS_FRAME}
+          </SwitchItem>
+          <SwitchItem
             note={Messages.POWERCORD_SETTINGS_EXP_WEB_PLATFORM_DESC.format()}
             value={getSetting('experimentalWebPlatform', false)}
             onChange={() => {

--- a/src/browserWindow.js
+++ b/src/browserWindow.js
@@ -9,12 +9,14 @@ const { BrowserWindow } = require('electron');
 
 let settings = {};
 let transparency = false;
+let frame = true;
 let ewp = false;
 try {
-  settings = require(join(__dirname, '../../settings/pc-general.json'));
+  settings = require(join(__dirname, '../settings/pc-general.json'));
   transparency = settings.transparentWindow;
+  frame = settings.windowFrame;
   ewp = settings.experimentalWebPlatform;
-} catch (e) {}
+} catch (e) { console.error(e) }
 
 class PatchedBrowserWindow extends BrowserWindow {
   // noinspection JSAnnotator - Make JetBrains happy
@@ -41,8 +43,11 @@ class PatchedBrowserWindow extends BrowserWindow {
 
       if (transparency) {
         opts.transparent = true;
-        opts.frame = process.platform === 'win32' ? false : opts.frame;
         delete opts.backgroundColor;
+      }
+
+      if (!frame) {
+        opts.frame = false;
       }
 
       if (ewp) {

--- a/src/browserWindow.js
+++ b/src/browserWindow.js
@@ -16,7 +16,7 @@ try {
   transparency = settings.transparentWindow;
   frame = settings.windowFrame;
   ewp = settings.experimentalWebPlatform;
-} catch (e) { console.error(e) }
+} catch (e) { }
 
 class PatchedBrowserWindow extends BrowserWindow {
   // noinspection JSAnnotator - Make JetBrains happy


### PR DESCRIPTION
This fixes a bug that caused the try catch statement in browserWindow.js to always fail as a result from the require path going back one directory too far. It also adds an option to the advanced settings that allows toggling of the window frame. I've only added English translations because I do not have any other language skill and using an online translator isn't the best way.