### PR TITLE
Remove call to undefined function

### DIFF
--- a/src/Powercord/plugins/pc-spotify/index.js
+++ b/src/Powercord/plugins/pc-spotify/index.js
@@ -62,7 +62,7 @@ class Spotify extends Plugin {
   pluginWillUnload () {
     uninject('pc-spotify-socket');
     uninject('pc-spotify-modal');
-    this._applySocketChanges();
+    //this._applySocketChanges();
     this._patchAutoPause(true);
     Object.values(commands).forEach(cmd => powercord.api.commands.unregisterCommand(cmd.command));
     powercord.api.settings.unregisterSettings('pc-spotify');

--- a/src/Powercord/plugins/pc-spotify/index.js
+++ b/src/Powercord/plugins/pc-spotify/index.js
@@ -62,7 +62,7 @@ class Spotify extends Plugin {
   pluginWillUnload () {
     uninject('pc-spotify-socket');
     uninject('pc-spotify-modal');
-    //this._applySocketChanges();
+    // this._applySocketChanges();
     this._patchAutoPause(true);
     Object.values(commands).forEach(cmd => powercord.api.commands.unregisterCommand(cmd.command));
     powercord.api.settings.unregisterSettings('pc-spotify');


### PR DESCRIPTION
This plugin would fail to unload at this point, and cause a funky graphical error to anyone using a plugin such as Panikk (or alternatively, someone stupid enough to run `powercord.shutdown()`. 

Though I'm not too sure of the "loss" caused by not applying changes to the socket (I haven't dug through history to find what this was doing or why it exists) this solves that problem and in my testing doesn't cause any further issues.