### PR TITLE
Add --server flag to .saveemote command

### DIFF
--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -18,7 +18,9 @@ const KnownLinuxPaths = Object.freeze([
   '/usr/lib64/discord-canary',
   '/opt/discord-canary',
   '/opt/DiscordCanary',
-  `${homedir}/.local/bin/DiscordCanary` // https://github.com/powercord-org/powercord/pull/370
+  `${homedir}/.local/bin/DiscordCanary`, // https://github.com/powercord-org/powercord/pull/370
+  '/var/lib/flatpak/app/com.discordapp.DiscordCanary/current/active/files/discord-canary', // flatpak system install https://github.com/flathub/com.discordapp.DiscordCanary
+  `${homedir}/.local/share/flatpak/app/com.discordapp.DiscordCanary/current/active/files/discord-canary` // flatpak user install
 ]);
 
 

--- a/injectors/main.js
+++ b/injectors/main.js
@@ -21,6 +21,12 @@ exports.inject = async ({ getAppDir }) => {
     console.log(`${AnsiEscapes.YELLOW}NOTE:${AnsiEscapes.RESET} If you already have BetterDiscord or another client mod injected, Powercord cannot run along with it!`);
     console.log('Read our FAQ for more details: https://powercord.dev/faq#bd-and-pc');
     return false;
+  } else if (appDir.includes('flatpak')) {
+    const command = appDir.startsWith('/var') ? 'sudo flatpak override' : 'flatpak override --user';
+
+    console.log(`${AnsiEscapes.YELLOW}NOTE:${AnsiEscapes.RESET} It seems like your Discord Canary install is a flatpak`);
+    console.log('      You need to update its permissions so it can access the powercord directory');
+    console.log(`      You can do so by running ${AnsiEscapes.YELLOW}${command} --filesystem=${join(__dirname, '..')} com.discordapp.DiscordCanary${AnsiEscapes.RESET}`);
   }
 
   await mkdir(appDir);

--- a/src/Powercord/plugins/pc-emojiUtility/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-emojiUtility/components/Settings.jsx
@@ -87,6 +87,14 @@ module.exports = class EmojiUtilitySettings extends React.Component {
         </TextInput>
 
         <SwitchItem
+          note='Whether a separate folder should be created when downloading emotes with the --server flag.'
+          value={this.props.getSetting('createGuildFolders')}
+          onChange={() => this.props.toggleSetting('createGuildFolders')}
+        >
+          Create separate folder when exporting with --server flag
+        </SwitchItem>
+
+        <SwitchItem
           note='Whether saving emotes should contain the id of the emote, this prevents overwriting old saved emotes.'
           value={this.props.getSetting('includeIdForSavedEmojis')}
           onChange={() => this.props.toggleSetting('includeIdForSavedEmojis')}

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -225,7 +225,7 @@ module.exports = class EmojiUtility extends Plugin {
     /* Default settings */
     this.settings.set('useEmbeds', this.settings.get('useEmbeds', false));
     this.settings.set('displayLink', this.settings.get('displayLink', true));
-    this.settings.set('createGuildFolder', this.settings.get('createGuildFolder', true));
+    this.settings.set('createGuildFolders', this.settings.get('createGuildFolders', true));
     this.settings.set('includeIdForSavedEmojis', this.settings.get('includeIdForSavedEmojis', true));
     this.settings.set('defaultCloneIdUseCurrent', this.settings.get('defaultCloneIdUseCurrent', false));
 

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -619,7 +619,7 @@ module.exports = class EmojiUtility extends Plugin {
       description: 'Save emotes to a specified directory',
       usage: '{c} [--server | emote]',
       executor: async (args) => {
-        let filePath = this.settings.get('filePath')
+        let filePath = this.settings.get('filePath');
         if (!filePath) {
           return this.replyError('Please set your save directory in the settings');
         }
@@ -631,13 +631,17 @@ module.exports = class EmojiUtility extends Plugin {
         let foundEmojis, notFoundEmojis;
         if (args.includes('--server')) {
           const { guild_id } = this.getChannel(this.getChannelId());
-          if (!guild_id) return this.replyError('The --server flag can not be used in dms');
+          if (!guild_id) {
+            return this.replyError('The --server flag can not be used in dms');
+          }
 
           if (this.settings.get('createGuildFolders')) {
             const guild = this.getGuildByIdOrName(guild_id);
 
             filePath = join(filePath, guild.name);
-            if (!existsSync(filePath)) mkdirSync(filePath);
+            if (!existsSync(filePath)) {
+              mkdirSync(filePath);
+            }
           }
 
           foundEmojis = this.getEmojis(guild_id);

--- a/src/Powercord/plugins/pc-emojiUtility/index.js
+++ b/src/Powercord/plugins/pc-emojiUtility/index.js
@@ -21,10 +21,10 @@ const { inject, uninject } = require('powercord/injector');
 const { open: openModal } = require('powercord/modal');
 
 const { writeFile } = require('fs').promises;
-const { existsSync } = require('fs');
+const { existsSync, mkdirSync } = require('fs');
 
 const { get } = require('powercord/http');
-const { extname, resolve } = require('path');
+const { extname, resolve, join } = require('path');
 const { parse } = require('url');
 
 const { clipboard } = require('electron');
@@ -225,6 +225,7 @@ module.exports = class EmojiUtility extends Plugin {
     /* Default settings */
     this.settings.set('useEmbeds', this.settings.get('useEmbeds', false));
     this.settings.set('displayLink', this.settings.get('displayLink', true));
+    this.settings.set('createGuildFolder', this.settings.get('createGuildFolder', true));
     this.settings.set('includeIdForSavedEmojis', this.settings.get('includeIdForSavedEmojis', true));
     this.settings.set('defaultCloneIdUseCurrent', this.settings.get('defaultCloneIdUseCurrent', false));
 
@@ -616,22 +617,38 @@ module.exports = class EmojiUtility extends Plugin {
     powercord.api.commands.registerCommand({
       command: 'saveemote',
       description: 'Save emotes to a specified directory',
-      usage: '{c} [emote]',
+      usage: '{c} [--server | emote]',
       executor: async (args) => {
-        if (!this.settings.get('filePath')) {
+        let filePath = this.settings.get('filePath')
+        if (!filePath) {
           return this.replyError('Please set your save directory in the settings');
         }
 
-        if (!existsSync(this.settings.get('filePath'))) {
+        if (!existsSync(filePath)) {
           return this.replyError('The specified save directory does no longer exist, please update it in the settings');
         }
 
-        const object = this.findEmojisForCommand(args);
-        if (!object) {
-          return;
-        }
+        let foundEmojis, notFoundEmojis;
+        if (args.includes('--server')) {
+          const { guild_id } = this.getChannel(this.getChannelId());
+          if (!guild_id) return this.replyError('The --server flag can not be used in dms');
 
-        const { foundEmojis, notFoundEmojis } = object;
+          if (this.settings.get('createGuildFolders')) {
+            const guild = this.getGuildByIdOrName(guild_id);
+
+            filePath = join(filePath, guild.name);
+            if (!existsSync(filePath)) mkdirSync(filePath);
+          }
+
+          foundEmojis = this.getEmojis(guild_id);
+          notFoundEmojis = [];
+        } else {
+          const object = this.findEmojisForCommand(args);
+          if (!object) {
+            return;
+          }
+          ({ foundEmojis, notFoundEmojis } = object);
+        }
 
         if (notFoundEmojis.length > 0) {
           return this.replyError(`**${notFoundEmojis.length}** of the provided arguments ${notFoundEmojis.length === 1 ? 'is not a custom emote' : 'are not custom emotes'}`);
@@ -642,7 +659,7 @@ module.exports = class EmojiUtility extends Plugin {
             try {
               const name = this.settings.get('includeIdForSavedEmojis') ? `${emoji.name} (${emoji.id})` : emoji.name;
 
-              await writeFile(resolve(this.settings.get('filePath'), name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
+              await writeFile(resolve(filePath, name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
 
               this.replySuccess(`Downloaded ${this.getFullEmoji(emoji)}`);
             } catch (error) {
@@ -665,7 +682,7 @@ module.exports = class EmojiUtility extends Plugin {
             try {
               const name = this.settings.get('includeIdForSavedEmojis') ? `${emoji.name} (${emoji.id})` : emoji.name;
 
-              await writeFile(resolve(this.settings.get('filePath'), name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
+              await writeFile(resolve(filePath, name + extname(parse(emoji.url).pathname)), (await get(emoji.url)).raw);
             } catch (error) {
               console.error(error);
 

--- a/src/Powercord/plugins/pc-moduleManager/commands/enable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/enable.js
@@ -35,7 +35,7 @@ module.exports = {
 
     return {
       commands: plugins
-        .filter(plugin => plugin.entityID.includes(args[0]))
+        .filter(plugin => plugin.entityID.toLowerCase().includes((args[0] || '').toLowerCase()))
         .map(plugin => ({
           command: plugin.entityID,
           description: plugin.manifest.description

--- a/src/Powercord/plugins/pc-moduleManager/commands/reload.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/reload.js
@@ -1,24 +1,24 @@
 module.exports = {
-  command: 'disable',
-  description: 'Allows you to disable a selected plugin from the given list.',
+  command: 'reload',
+  description: 'Allows you to reload a selected plugin from the given list.',
   usage: '{c} [ plugin ID ]',
-  executor (args) {
+  async executor (args) {
     let result;
 
     if (powercord.pluginManager.plugins.has(args[0])) {
       if (args[0] === 'pc-commands') {
-        result = `->> ERROR: You cannot unload this plugin as it depends on delivering these commands!
-            (Tried to unload ${args[0]})`;
+        result = `->> ERROR: You cannot reload this plugin as it depends on delivering these commands!
+            (Tried to reload ${args[0]})`;
       } else if (!powercord.pluginManager.isEnabled(args[0])) {
-        result = `->> ERROR: Tried to unload a non-loaded plugin!
+        result = `->> ERROR: Tried to reload a non-loaded plugin!
             (${args[0]})`;
       } else {
-        powercord.pluginManager.disable(args[0]);
-        result = `+>> SUCCESS: Plugin unloaded!
+        await powercord.pluginManager.remount(args[0]);
+        result = `+>> SUCCESS: Plugin reloaded!
             (${args[0]})`;
       }
     } else {
-      result = `->> ERROR: Tried to disable a non-installed plugin!
+      result = `->> ERROR: Tried to reload a non-installed plugin!
           (${args[0]})`;
     }
 


### PR DESCRIPTION
This flag downloads all emotes of the current guild. By default, a separate folder will be created but this is toggleable in the settings


Closed because I accidently merged the feature branch with my other changes and too lazy to reopen it