### PR TITLE
Reload command

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/commands/enable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/enable.js
@@ -35,7 +35,7 @@ module.exports = {
 
     return {
       commands: plugins
-        .filter(plugin => plugin.entityID.includes(args[0]))
+        .filter(plugin => plugin.entityID.toLowerCase().includes((args[0] || '').toLowerCase()))
         .map(plugin => ({
           command: plugin.entityID,
           description: plugin.manifest.description

--- a/src/Powercord/plugins/pc-moduleManager/commands/reload.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/reload.js
@@ -1,24 +1,24 @@
 module.exports = {
-  command: 'disable',
-  description: 'Allows you to disable a selected plugin from the given list.',
+  command: 'reload',
+  description: 'Allows you to reload a selected plugin from the given list.',
   usage: '{c} [ plugin ID ]',
-  executor (args) {
+  async executor (args) {
     let result;
 
     if (powercord.pluginManager.plugins.has(args[0])) {
       if (args[0] === 'pc-commands') {
-        result = `->> ERROR: You cannot unload this plugin as it depends on delivering these commands!
-            (Tried to unload ${args[0]})`;
+        result = `->> ERROR: You cannot reload this plugin as it depends on delivering these commands!
+            (Tried to reload ${args[0]})`;
       } else if (!powercord.pluginManager.isEnabled(args[0])) {
-        result = `->> ERROR: Tried to unload a non-loaded plugin!
+        result = `->> ERROR: Tried to reload a non-loaded plugin!
             (${args[0]})`;
       } else {
-        powercord.pluginManager.disable(args[0]);
-        result = `+>> SUCCESS: Plugin unloaded!
+        await powercord.pluginManager.remount(args[0]);
+        result = `+>> SUCCESS: Plugin reloaded!
             (${args[0]})`;
       }
     } else {
-      result = `->> ERROR: Tried to disable a non-installed plugin!
+      result = `->> ERROR: Tried to reload a non-installed plugin!
           (${args[0]})`;
     }
 


### PR DESCRIPTION
Adds a reload command to pc-moduleManager which remounts the specified plugin. This is extremly useful for development as you can now reload plugins without having to restart discord. Additionally, the autocomplete of enable and disable is now case insensitive