### PR TITLE
Add flatpak support

### DIFF
--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -18,7 +18,9 @@ const KnownLinuxPaths = Object.freeze([
   '/usr/lib64/discord-canary',
   '/opt/discord-canary',
   '/opt/DiscordCanary',
-  `${homedir}/.local/bin/DiscordCanary` // https://github.com/powercord-org/powercord/pull/370
+  `${homedir}/.local/bin/DiscordCanary`, // https://github.com/powercord-org/powercord/pull/370
+  '/var/lib/flatpak/app/com.discordapp.DiscordCanary/current/active/files/discord-canary', // flatpak system install https://github.com/flathub/com.discordapp.DiscordCanary
+  `${homedir}/.local/share/flatpak/app/com.discordapp.DiscordCanary/current/active/files/discord-canary` // flatpak user install
 ]);
 
 

--- a/injectors/main.js
+++ b/injectors/main.js
@@ -21,6 +21,12 @@ exports.inject = async ({ getAppDir }) => {
     console.log(`${AnsiEscapes.YELLOW}NOTE:${AnsiEscapes.RESET} If you already have BetterDiscord or another client mod injected, Powercord cannot run along with it!`);
     console.log('Read our FAQ for more details: https://powercord.dev/faq#bd-and-pc');
     return false;
+  } else if (appDir.includes('flatpak')) {
+    const command = appDir.startsWith('/var') ? 'sudo flatpak override' : 'flatpak override --user';
+
+    console.log(`${AnsiEscapes.YELLOW}NOTE:${AnsiEscapes.RESET} It seems like your Discord Canary install is a flatpak`);
+    console.log('      You need to update its permissions so it can access the powercord directory');
+    console.log(`      You can do so by running ${AnsiEscapes.YELLOW}${command} --filesystem=${join(__dirname, '..')} com.discordapp.DiscordCanary${AnsiEscapes.RESET}`);
   }
 
   await mkdir(appDir);


### PR DESCRIPTION
Adds flatpak paths and prints permission override note for flatpak users

___

#### Additional note for flatpak users finding this PR (might want to add this to README in case this gets merged? idk)

Due to flatpaks being sandboxed, powercord doesn't have access to the git binary which breaks auto updating. Assuming your powercord folder is in `~/.local/share/powercord`, you can use this simple script to update all your plugins manually
```bash
#!/bin/bash
shopt -s globstar

for folder in ~/.local/share/powercord/**/.git; do
  (cd "$folder/.." && echo "Pulling $PWD" && git pull)
done
```
