### PR TITLE
Fix regex related to the error below

### DIFF
--- a/src/Powercord/coremods/utility-classes/modules/avatars.js
+++ b/src/Powercord/coremods/utility-classes/modules/avatars.js
@@ -13,7 +13,7 @@ module.exports = async () => {
   inject('pc-utilitycls-avatar', Avatar, 'default', (args, res) => {
     const avatar = args[0].src || void 0;
     if (avatar && avatar.includes('/avatars')) {
-      [ , res.props['data-user-id'] ] = avatar.match(/\/avatars\/(\d+)/);
+      [ , res.props['data-user-id'] ] = avatar.match(/\/(?:avatars|users)\/(\d+)/);
     }
 
     return res;


### PR DESCRIPTION
```
[Powercord:Injector] Failed to run injection "pc-utilitycls-avatar" TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
```

Error is given when hovering members in members list and because sometimes discord returns the user avatar as `https://cdn.discordapp.com/guilds/538759280057122817/users/786891541557018624/avatars/609ab04f6b31131b13b7e293d4187949.webp` and not as usual(`https://cdn.discordapp.com/avatars/786891541557018624/609ab04f6b31131b13b7e293d4187949.webp`) the regex don't match it and gives that error