### PR TITLE
fix codeblock copy button text color on light theme

### DIFF
--- a/src/Powercord/plugins/pc-codeblocks/style.css
+++ b/src/Powercord/plugins/pc-codeblocks/style.css
@@ -38,7 +38,7 @@
 }
 
 .powercord-codeblock-copy-btn {
-  color: #fff;
+  color: var(--text-normal);
   border-radius: 4px;
 
   line-height: 20px;
@@ -58,6 +58,7 @@
 }
 
 .powercord-codeblock-copy-btn.copied {
+  color: #fff;
   background-color: #43b581;
   opacity: 1;
 }


### PR DESCRIPTION
changes the css for the pc-codeblocks plugin to use `--text-normal` for the color of the button text to make the text visible on light theme.