### PR TITLE
Fix autocomplete causing crashes

### DIFF
--- a/src/Powercord/plugins/pc-commands/injectAutocomplete.js
+++ b/src/Powercord/plugins/pc-commands/injectAutocomplete.js
@@ -51,8 +51,8 @@ module.exports = async function injectAutocomplete () {
           autocompleteRows.value = value
           autocompleteRows.commands.__header = [ autocompleteRows.header ];
           delete autocompleteRows.header;
+          return { results: autocompleteRows };
         }
-        return { results: autocompleteRows };
       }
 
       return { results: {} };


### PR DESCRIPTION
Discord now crashes when a plugin returns `undefined` from the autocomplete handler. This causes commands like .tag and .lmgtfy to crash when used.

The fix is simple, just return `results: {}` when a plugin returns undefined