### PR TITLE
case insensitive autocomplete

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/commands/disable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/disable.js
@@ -40,7 +40,7 @@ module.exports = {
     return {
       commands: plugins
         .filter(plugin => plugin.entityID !== 'pc-commands' &&
-          plugin.entityID.includes(args[0]))
+          plugin.entityID.toLowerCase().includes(args[0].toLowerCase()))
         .map(plugin => ({
           command: plugin.entityID,
           description: plugin.manifest.description

--- a/src/Powercord/plugins/pc-moduleManager/commands/enable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/enable.js
@@ -35,7 +35,7 @@ module.exports = {
 
     return {
       commands: plugins
-        .filter(plugin => plugin.entityID.includes(args[0]))
+        .filter(plugin => plugin.entityID.toLowerCase().includes(args[0].toLowerCase()))
         .map(plugin => ({
           command: plugin.entityID,
           description: plugin.manifest.description


### PR DESCRIPTION
this makes the enable and disable plugin commands case insensitive.
![scrot](https://user-images.githubusercontent.com/36301891/130953407-17d9a6a5-e265-4c22-854e-d0d44069fbc7.png)
