### PR TITLE
[Spotify plugin] Stop share command with args from crashing Discord

### DIFF
--- a/src/Powercord/plugins/pc-spotify/commands/share.js
+++ b/src/Powercord/plugins/pc-spotify/commands/share.js
@@ -18,7 +18,7 @@ module.exports = {
 
       if (result.tracks.items.length > 1) {
         return openModal(() => React.createElement(ShareModal, {
-          tracks: result.tracks,
+          tracks: result.tracks.items,
           query
         }));
       } else if (closestTrack) {


### PR DESCRIPTION
Currently, running `{powercord prefix}share` with any arguements crashes Discord as `result.tracks` should be `result.tracks.items`.
This commit fixes it and shows the share modal as it should.