### PR TITLE
Fix query selector in pc-codeblocks

### DIFF
--- a/src/Powercord/plugins/pc-codeblocks/index.js
+++ b/src/Powercord/plugins/pc-codeblocks/index.js
@@ -94,6 +94,6 @@ module.exports = class Codeblocks extends Plugin {
   }
 
   _forceUpdate () {
-    document.querySelectorAll('[id^="chat-messages-"]').forEach(e => getReactInstance(e).memoizedProps.onMouseMove());
+    document.querySelectorAll('[id^="chat-messages-"] > div').forEach(e => getReactInstance(e).memoizedProps.onMouseMove());
   }
 };


### PR DESCRIPTION
For whatever reason, chat message elements are now nested by one, so instead of being by themselves, they now have an `li` parent.