### PR TITLE
Fixed the main Settings Panel error.

### DIFF
--- a/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
+++ b/src/Powercord/plugins/pc-settings/components/GeneralSettings/index.jsx
@@ -98,7 +98,7 @@ module.exports = class GeneralSettings extends React.Component {
             {Messages.POWERCORD_SETTINGS_TRANSPARENT}
           </SwitchItem>
           <SwitchItem
-            note={Messages.POWERCORD_SETTINGS_EXP_WEB_PLATFORM_DESC.format()}
+            note={Messages.POWERCORD_SETTINGS_EXP_WEB_PLATFORM_DESC}
             value={getSetting('experimentalWebPlatform', false)}
             onChange={() => {
               toggleSetting('experimentalWebPlatform');


### PR DESCRIPTION
Removed the `format()` function from the `Messages.POWERCORD_SETTINGS_EXP_WEB_PLATFORM_DESC` string, because it causes the main Powercord Settings Panel not to render because of a ReferenceError.