### PR TITLE
fix: ignore .DS_Store when loading modules

### DIFF
--- a/src/Powercord/modules/index.js
+++ b/src/Powercord/modules/index.js
@@ -1,4 +1,4 @@
 module.exports = require('fs')
   .readdirSync(__dirname)
-  .filter(file => ['index.js', '.DS_Store'].includes(file))
+  .filter(file => !['index.js', '.DS_Store'].includes(file))
   .map(filename => require(`${__dirname}/${filename}`));

--- a/src/Powercord/modules/index.js
+++ b/src/Powercord/modules/index.js
@@ -1,4 +1,4 @@
 module.exports = require('fs')
   .readdirSync(__dirname)
-  .filter(file => file !== 'index.js')
+  .filter(file => ['index.js', '.DS_Store'].includes(file))
   .map(filename => require(`${__dirname}/${filename}`));


### PR DESCRIPTION
closes powercord-org/powercord#571