### PR TITLE
Better injector handling on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ settings/*.json
 config.json
 *injected.txt
 *.nogit.*
+
+.installdir

--- a/injectors/elevate.js
+++ b/injectors/elevate.js
@@ -5,10 +5,29 @@
  */
 
 const { spawnSync } = require('child_process');
+const { existsSync } = require('fs');
+const { BasicMessages, AnsiEscapes } = require('./log');
+const { delimiter } = require('path');
+
+function hasInPath(exe) {
+  return (process.env.PATH || '')
+    .replace(/["]+/g, "")
+    .split(delimiter)
+    .find(p => existsSync(p + '/' + exe)) ? true : false
+}
 
 // It seems `sudo npm ...` no longer give the script sudo perms in npm v7, so here we are.
 if (process.platform === 'linux' && process.getuid() !== 0) {
-  // todo: decide whether this is a viable solution for the long term. people may use doas or other tools for elevating themselves.
-  spawnSync('sudo', process.argv, { stdio: 'inherit' })
-  process.exit(0)
+  process.argv.push('--sudo'); // to avoid infinite recursion
+  if (hasInPath('sudo')) {
+    spawnSync('sudo', process.argv, { stdio: 'inherit' });
+  } else if (hasInPath('doas')) {
+    spawnSync('doas', process.argv, { stdio: 'inherit' });
+  } else {
+    console.log('');
+    console.log(BasicMessages.PLUG_FAILED);
+    console.log('Failed to run \'sudo\' or \'doas\' to elevate script permissions!');
+    process.exit(process.argv.includes('--no-exit-codes') ? 0 : 1);
+  }
+  process.exit(0);
 }

--- a/injectors/index.js
+++ b/injectors/index.js
@@ -4,7 +4,6 @@
  * https://powercord.dev/porkord-license
  */
 
-require('./elevate');
 require('./env_check')(); // Perform checks
 require('../polyfills'); // And then do stuff
 
@@ -50,10 +49,14 @@ try {
   }
 })().catch(e => {
   if (e.code === 'EACCES') {
-    // todo: this was linux only (?) so I assume this is now safe to delete
-    console.log(process.argv[2] === 'inject' ? BasicMessages.PLUG_FAILED : BasicMessages.UNPLUG_FAILED, '\n');
-    console.log('Powercord wasn\'t able to inject itself due to missing permissions.', '\n');
-    console.log('Try again with elevated permissions.');
+    if (process.platform === 'linux' && !process.argv.includes('--sudo')) {
+      console.log(`${AnsiEscapes.YELLOW}Powercord wasn't able to inject itself due to missing permissions, attempting to re-run as sudo..${AnsiEscapes.RESET}`, '\n');
+      require('./elevate');
+    } else {
+      console.log(process.argv[2] === 'inject' ? BasicMessages.PLUG_FAILED : BasicMessages.UNPLUG_FAILED, '\n');
+      console.log('Powercord wasn\'t able to inject itself due to missing permissions.', '\n');
+      console.log('Try again with elevated permissions.');
+    }
   } else {
     console.error('fucky wucky', e);
   }

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -5,7 +5,7 @@
  */
 
 const { join } = require('path');
-const { existsSync } = require('fs');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
 const { execSync } = require('child_process');
 const readline = require('readline');
 const { BasicMessages, AnsiEscapes } = require('./log');
@@ -21,8 +21,9 @@ const KnownLinuxPaths = Object.freeze([
   `${homedir}/.local/bin/DiscordCanary` // https://github.com/powercord-org/powercord/pull/370
 ]);
 
+const installDirFile = __dirname + '/../.installdir';
 
-exports.getAppDir = async () => {
+async function findAppDir() {
   const discordProcess = execSync('ps x')
     .toString()
     .split('\n')
@@ -57,4 +58,14 @@ exports.getAppDir = async () => {
   const discordPath = discordProcess[4].split('/');
   discordPath.splice(discordPath.length - 1, 1);
   return join('/', ...discordPath, 'resources', 'app');
+}
+
+exports.getAppDir = async () => {
+  if (existsSync(installDirFile)) {
+    return readFileSync(installDirFile, 'utf8');
+  } else {
+    let appDir = await findAppDir()
+    writeFileSync(installDirFile, appDir);
+    return appDir;
+  }
 };


### PR DESCRIPTION
Currently, if a user is using a non-standard Discord install location, they will have to enter it each time they inject and uninject Powercord. This PR will fix this by creating an `.installdir` file and using that if possible.
Additionally, the script will fail if the user uses `doas` (and doesn't have a `sudo` shim or similar). It will now instead check for both, then fail gracefully if neither are found.