### PR TITLE
Add react import in pc-commands/components/Title

### DIFF
--- a/src/Powercord/plugins/pc-commands/components/Title.jsx
+++ b/src/Powercord/plugins/pc-commands/components/Title.jsx
@@ -1,4 +1,4 @@
-const { getModuleByDisplayName } = require('powercord/webpack');
+const { React, getModuleByDisplayName } = require('powercord/webpack');
 
 const Autocomplete = getModuleByDisplayName('Autocomplete', false);
 


### PR DESCRIPTION
this fixes the crash in the built in tags plugin