### PR TITLE
override safeStorage related IPC call for Electron 13

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -279,6 +279,13 @@ if (global.NEW_BACKEND) {
   }
 }
 
+if (!global.NEW_BACKEND) {
+  // Electron 13 requires this because Discord's handler tries to access safeStorage and throws.
+  require('electron').ipcMain.on('DISCORD_SAFE_STORAGE_IS_ENCRYPTION_AVAILABLE', (event) => {
+    event.returnValue = false;
+  });
+}
+
 // Add Powercord's modules
 require('module').Module.globalPaths.push(join(__dirname, 'fake_node_modules'));
 


### PR DESCRIPTION
Discord backported Electron's safeStorage API into their own build, which isn't availble for people using vanilla Electron 13 on linux.

This change gets the app launching again by overriding the event listener.

Original crash bug:
![image](https://user-images.githubusercontent.com/4871369/154750123-98f190fe-72f8-4672-9d98-fc99a71be9a1.png)

Fixes #618 probably