### PR TITLE
Fix not re-adding injected function's props

### DIFF
--- a/src/fake_node_modules/powercord/injector/index.js
+++ b/src/fake_node_modules/powercord/injector/index.js
@@ -31,6 +31,9 @@ const injector = {
       const id = Math.random().toString(16).slice(2);
       mod.__powercordInjectionId = Object.assign((mod.__powercordInjectionId || {}), { [funcName]: id });
       mod[`__powercordOriginal_${funcName}`] = mod[funcName]; // To allow easier debugging
+
+      const funcCopy = { ...mod }[funcName];
+
       mod[funcName] = (_oldMethod => function (...args) {
         const start = process.hrtime.bigint();
         const finalArgs = injector._runPreInjections(id, args, this);
@@ -55,6 +58,9 @@ const injector = {
           return res;
         }
       })(mod[funcName]);
+
+      Object.assign(mod[funcName], funcCopy);
+      mod[funcName].toString = () => funcCopy.toString();
 
       injector.injections[id] = [];
     }


### PR DESCRIPTION
You're free. No more forgetting to re-add the `displayName` to your injected React components.