### PR TITLE
Add commands for plugging stable, PTB, and development

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ As of right now, Powercord is in *very* early stages of development, so feel fre
 See the [installation page of the Powercord Wiki](https://github.com/powercord-org/powercord/wiki/Installation).
 
 # How can I install Powercord on Stable or PTB?
-You can't. We internally discussed about supporting all Discord channels and even ran an experiment about it, but that didn't give great results.
-Powercord was not able to run in some scenarios due to the huge internal differences and made the whole client unusable (crash on start).
+Injecting to Stable or PTB is unsupported. These versions may not work properly and support will not be given. However, if you wish to use these versions, you can use `npm run plug stable` or `npm run plug ptb` respectively. The `unplug` command works the same way.
 
 # Is this against the ToS?
 Long story short... __yes__. Powercord is against the Discord Terms of Service — but, you should keep reading:  

--- a/injectors/darwin.js
+++ b/injectors/darwin.js
@@ -1,1 +1,8 @@
-exports.getAppDir = async () => '/Applications/Discord Canary.app/Contents/Resources/app';
+const PATHS = {
+  stable: '/Applications/Discord.app/Contents/Resources/app',
+  ptb: '/Applications/Discord PTB.app/Contents/Resources/app',
+  canary: '/Applications/Discord Canary.app/Contents/Resources/app',
+  dev: '/Applications/Discord Development.app/Contents/Resources/app'
+};
+
+exports.getAppDir = async (platform) => PATHS[platform];

--- a/injectors/linux.js
+++ b/injectors/linux.js
@@ -2,29 +2,58 @@ const { join } = require('path');
 const { existsSync } = require('fs');
 const { execSync } = require('child_process');
 const readline = require('readline');
-const { BasicMessages, AnsiEscapes } = require('./log');
+const { BasicMessages, AnsiEscapes, PlatformNames } = require('./log');
 
 // This is to ensure the homedir we get is the actual user's homedir instead of root's homedir
 const homedir = execSync('grep $(logname) /etc/passwd | cut -d ":" -f6').toString().trim();
 
-const KnownLinuxPaths = Object.freeze([
-  '/usr/share/discord-canary',
-  '/usr/lib64/discord-canary',
-  '/opt/discord-canary',
-  '/opt/DiscordCanary',
-  `${homedir}/.local/bin/DiscordCanary` // https://github.com/powercord-org/powercord/pull/370
-]);
+const KnownLinuxPaths = Object.freeze({
+  stable: [
+    '/usr/share/discord',
+    '/usr/lib64/discord',
+    '/opt/discord',
+    '/opt/Discord',
+    `${homedir}/.local/bin/Discord`
+  ],
+  ptb: [
+    '/usr/share/discord-ptb',
+    '/usr/lib64/discord-ptb',
+    '/opt/discord-ptb',
+    '/opt/DiscordPTB',
+    `${homedir}/.local/bin/DiscordPTB`
+  ],
+  canary: [
+    '/usr/share/discord-canary',
+    '/usr/lib64/discord-canary',
+    '/opt/discord-canary',
+    '/opt/DiscordCanary',
+    `${homedir}/.local/bin/DiscordCanary` // https://github.com/powercord-org/powercord/pull/370
+  ],
+  dev: [
+    '/usr/share/discord-development',
+    '/usr/lib64/discord-development',
+    '/opt/discord-development',
+    '/opt/DiscordDevelopment',
+    `${homedir}/.local/bin/DiscordDevelopment`
+  ]
+});
 
+const ProcessRegex = {
+  stable: /discord$/i,
+  ptb: /discord-?ptb$/i,
+  canary: /discord-?canary$/i,
+  dev: /discord-?development$/i
+};
 
-exports.getAppDir = async () => {
+exports.getAppDir = async (platform) => {
   const discordProcess = execSync('ps x')
     .toString()
     .split('\n')
     .map(s => s.split(' ').filter(Boolean))
-    .find(p => p[4] && (/discord-?canary$/i).test(p[4]) && p.includes('--type=renderer'));
+    .find(p => p[4] && (ProcessRegex[platform]).test(p[4]) && p.includes('--type=renderer'));
 
   if (!discordProcess) {
-    let discordPath = KnownLinuxPaths.find(path => existsSync(path));
+    let discordPath = KnownLinuxPaths[platform].find(path => existsSync(path));
     if (!discordPath) {
       const readlineInterface = readline.createInterface({
         input: process.stdin,
@@ -32,8 +61,8 @@ exports.getAppDir = async () => {
       });
 
       const askPath = () => new Promise(resolve => readlineInterface.question('> ', resolve));
-      console.log(`${AnsiEscapes.YELLOW}Failed to locate Discord Canary installation folder.${AnsiEscapes.RESET}`, '\n');
-      console.log('Please provide the path of your Discord Canary installation folder');
+      console.log(`${AnsiEscapes.YELLOW}Failed to locate ${PlatformNames[platform]} installation folder.${AnsiEscapes.RESET}`, '\n');
+      console.log(`Please provide the path of your ${PlatformNames[platform]} installation folder`);
       discordPath = await askPath();
       readlineInterface.close();
 

--- a/injectors/log.js
+++ b/injectors/log.js
@@ -13,7 +13,15 @@ const BasicMessages = Object.freeze({
   UNPLUG_SUCCESS: `${AnsiEscapes.BOLD}${AnsiEscapes.GREEN}Powercord has been successfully unplugged${AnsiEscapes.RESET}`
 });
 
+const PlatformNames = Object.freeze({
+  stable: 'Discord',
+  ptb: 'Discord PTB',
+  canary: 'Discord Canary',
+  dev: 'Discord Development'
+});
+
 module.exports = {
   AnsiEscapes,
-  BasicMessages
+  BasicMessages,
+  PlatformNames
 };

--- a/injectors/main.js
+++ b/injectors/main.js
@@ -4,8 +4,8 @@ const { mkdir, writeFile } = require('fs').promises;
 const { join, sep } = require('path');
 const { AnsiEscapes } = require('./log');
 
-exports.inject = async ({ getAppDir }) => {
-  const appDir = await getAppDir();
+exports.inject = async ({ getAppDir }, platform) => {
+  const appDir = await getAppDir(platform);
   if (existsSync(appDir)) {
     /*
      * @todo: verify if there is nothing in discord_desktop_core as well
@@ -35,8 +35,8 @@ exports.inject = async ({ getAppDir }) => {
   return true;
 };
 
-exports.uninject = async ({ getAppDir }) => {
-  const appDir = await getAppDir();
+exports.uninject = async ({ getAppDir }, platform) => {
+  const appDir = await getAppDir(platform);
 
   if (!existsSync(appDir)) {
     console.log('There is nothing to unplug. You are already running Discord without mods.');

--- a/injectors/win32.js
+++ b/injectors/win32.js
@@ -1,8 +1,15 @@
 const { readdir } = require('fs').promises;
 const { join } = require('path');
 
-exports.getAppDir = async () => {
-  const discordPath = join(process.env.LOCALAPPDATA, 'DiscordCanary');
+const PATHS = {
+  stable: 'Discord',
+  ptb: 'DiscordPTB',
+  canary: 'DiscordCanary',
+  dev: 'DiscordDevelopment'
+};
+
+exports.getAppDir = async (platform) => {
+  const discordPath = join(process.env.LOCALAPPDATA, PATHS[platform]);
   const discordDirectory = await readdir(discordPath);
 
   const currentBuild = discordDirectory

--- a/src/browserWindow.js
+++ b/src/browserWindow.js
@@ -60,10 +60,10 @@ class PatchedBrowserWindow extends BrowserWindow {
   }
 
   static loadUrl (ogLoadUrl, url, opts) {
-    console.log(url);
-    if (url.match(/^https:\/\/canary\.discord(app)?\.com\/_powercord\//)) {
+    let match = url.match(/^https:\/\/((?:canary|ptb)\.)?discord(app)?\.com\/_powercord\//);
+    if (match) {
       this.webContents._powercordOgUrl = url;
-      return ogLoadUrl('https://canary.discord.com/app', opts);
+      return ogLoadUrl(`https://${match[1] || ''}discord.com/app`, opts);
     }
     return ogLoadUrl(url, opts);
   }

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -73,9 +73,9 @@ electron.app.once('ready', () => {
 
   // @todo: make this be not shit
   electron.session.defaultSession.webRequest.onBeforeRequest((details, done) => {
-    const domainMatch = details.url.match(/^https:\/\/((?:canary|ptb)\.)?discord(app)?\.com/);
+    const domainMatch = details.url.match(/^https:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com/);
     if (domainMatch) {
-      const domain = domainMatch[1];
+      const domain = domainMatch[0];
       if (details.url.startsWith(`${domain}/_powercord`)) {
       // It should get restored to _powercord url later
         done({ redirectURL: `${domain}/app` });

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -79,9 +79,6 @@ electron.app.once('ready', () => {
       if (details.url.startsWith(`${domain}/_powercord`)) {
       // It should get restored to _powercord url later
         done({ redirectURL: `${domain}/app` });
-      } else if (details.url.startsWith(`${domain}/_powercord`)) {
-      // It should get restored to _powercord url later
-        done({ redirectURL: `${domain}/app` });
       } else {
         done({});
       }

--- a/src/patcher.js
+++ b/src/patcher.js
@@ -73,12 +73,18 @@ electron.app.once('ready', () => {
 
   // @todo: make this be not shit
   electron.session.defaultSession.webRequest.onBeforeRequest((details, done) => {
-    if (details.url.startsWith('https://canary.discordapp.com/_powercord')) {
+    const domainMatch = details.url.match(/^https:\/\/((?:canary|ptb)\.)?discord(app)?\.com/);
+    if (domainMatch) {
+      const domain = domainMatch[1];
+      if (details.url.startsWith(`${domain}/_powercord`)) {
       // It should get restored to _powercord url later
-      done({ redirectURL: 'https://canary.discordapp.com/app' });
-    } else if (details.url.startsWith('https://canary.discord.com/_powercord')) {
+        done({ redirectURL: `${domain}/app` });
+      } else if (details.url.startsWith(`${domain}/_powercord`)) {
       // It should get restored to _powercord url later
-      done({ redirectURL: 'https://canary.discord.com/app' });
+        done({ redirectURL: `${domain}/app` });
+      } else {
+        done({});
+      }
     } else {
       done({});
     }


### PR DESCRIPTION
This adds commands for installing to Stable or PTB. This can be done by appending a version to the command: `npm run <plug|unplug> [stable|ptb|canary|dev|development]`. A warning will be given to the user and they will have to confirm before the install continues. 
<img width="927" alt="Screenshot on 2022-04-24 at 22 13 23" src="https://user-images.githubusercontent.com/14863373/165015251-574cea99-4150-4d3c-9bd4-047a472b4a9f.png">

I was only able to test injection on macOS. I was able to find the windows paths [here](https://www.reddit.com/r/discordapp/comments/dhiovp/comment/f3ofvrl/?utm_source=share&utm_medium=web2x&context=3) but I had to guess the Linux paths based on context.

I updated the info in the README, but the wiki still needs to be updated. You might want to move the README info to the wiki instead of where it currently is, but that is up to you. The information in the Discord server probably needs to be updated as well.

Closes #632
Also closes #647