### PR TITLE
Fix injectContextMenu not re-adding injected function's props

### DIFF
--- a/src/fake_node_modules/powercord/util/injectContextMenu.js
+++ b/src/fake_node_modules/powercord/util/injectContextMenu.js
@@ -80,6 +80,8 @@ async function injectContextMenu (injectionId, displayName, fn, pre = false) {
                     const res = ogContextMenu(...args);
                     return fn(args, res);
                   };
+                  Object.assign(memoizedReplacement, ogContextMenu);
+                  memoizedReplacement.toString = () => ogContextMenu.toString();
                 }
 
                 res.props.children.type = memoizedReplacement;


### PR DESCRIPTION
When using the util `injectContextMenu`, it overrides the `type` with its own function, losing any props that were originally attached to it, this can cause issues with other plugins or even libraries by accident, in this instance, the impacted library being XenoLib.  
![DiscordCanary_M17aYJVERe](https://user-images.githubusercontent.com/49841131/165647946-92c6c7b0-ec35-4622-9308-42c5578d21fb.png)  

This simply makes it do what is already being done [in the injector](https://github.com/powercord-org/powercord/blob/v2/src/fake_node_modules/powercord/injector/index.js#L62-L63).  
![DiscordCanary_qbhNnyTkrc](https://user-images.githubusercontent.com/49841131/165648082-8abd81a7-0615-4669-9cde-2073d984222d.png)
