### PR TITLE
fix: don't crash on command autocomplete

### DIFF
--- a/src/Powercord/plugins/pc-commands/components/Title.jsx
+++ b/src/Powercord/plugins/pc-commands/components/Title.jsx
@@ -1,5 +1,19 @@
 const { React, getModuleByDisplayName } = require('powercord/webpack');
+const { AsyncComponent } = require('powercord/components');
 
-const Autocomplete = getModuleByDisplayName('Autocomplete', false);
+module.exports = AsyncComponent.from(
+  (async () => {
+    const Autocomplete = await getModuleByDisplayName('Autocomplete');
 
-module.exports = Autocomplete.Title;
+    return (props) => {
+      const res = Autocomplete?.Title?.(props);
+      const EmptyContainer = <div style={{ padding: '4px' }}/>;
+
+      if (Array.isArray(props?.title) && !props.title[0]) {
+        return EmptyContainer;
+      }
+
+      return res || EmptyContainer;
+    };
+  })()
+);

--- a/src/Powercord/plugins/pc-commands/components/Title.jsx
+++ b/src/Powercord/plugins/pc-commands/components/Title.jsx
@@ -2,14 +2,4 @@ const { React, getModuleByDisplayName } = require('powercord/webpack');
 
 const Autocomplete = getModuleByDisplayName('Autocomplete', false);
 
-module.exports = class Title extends Autocomplete.Title {
-  render () {
-    const res = super.render();
-
-    if (!this.props.title[0]) {
-      return <div style={{ padding: '4px' }}/>;
-    }
-
-    return res;
-  }
-};
+module.exports = Autocomplete.Title;


### PR DESCRIPTION
This commit fixes #643 by using the vanilla Autocomplete.Title component. After testing, there is no regression that I could find from using the unpatched component rather than custom patched version.
