### PR TITLE
Fix: injectAutocomplete.js

### DIFF
--- a/src/Powercord/plugins/pc-commands/injectAutocomplete.js
+++ b/src/Powercord/plugins/pc-commands/injectAutocomplete.js
@@ -31,7 +31,12 @@ module.exports = async function injectAutocomplete () {
   }
 
   function getMatchingCommand (c) {
-    return [ c.command.toLowerCase(), ...(c.aliases?.map((alias) => alias.toLowerCase()) || []) ];
+    try {
+      return [ c.command.toLowerCase(), ...(c.aliases?.map((alias) => alias.toLowerCase()) || []) ];
+    } catch (e) {
+      console.error('%c[Powercord:Plugin:pc-commands]', 'color: #7289da', e);
+      return [];
+    }
   }
 
   const { AUTOCOMPLETE_OPTIONS: AutocompleteTypes, AUTOCOMPLETE_PRIORITY: AutocompletePriority } = await getModule([ 'AUTOCOMPLETE_OPTIONS' ]);

--- a/src/Powercord/plugins/pc-commands/injectAutocomplete.js
+++ b/src/Powercord/plugins/pc-commands/injectAutocomplete.js
@@ -30,11 +30,12 @@ module.exports = async function injectAutocomplete () {
     );
   }
 
+  const _this = this;
   function getMatchingCommand (c) {
-    try {
+    try { 
       return [ c.command.toLowerCase(), ...(c.aliases?.map((alias) => alias.toLowerCase()) || []) ];
     } catch (e) {
-      console.error('%c[Powercord:Plugin:pc-commands]', 'color: #7289da', e);
+      _this.warn("Plugin Command is missing key `command`", c, e);
       return [];
     }
   }
@@ -124,7 +125,6 @@ module.exports = async function injectAutocomplete () {
     }
   };
 
-  const _this = this;
   const ChannelEditorContainer = await getModuleByDisplayName('ChannelEditorContainer');
   inject('pc-commands-textarea', ChannelEditorContainer.prototype, 'render', function (_, res) {
     _this.instance = this;


### PR DESCRIPTION
Fix for developers who forget to add a command key to their command so instead of crashing, it just logs the error.