### PR TITLE
fix: don't attempt to disable plugins twice

### DIFF
--- a/src/Powercord/managers/plugins.js
+++ b/src/Powercord/managers/plugins.js
@@ -140,6 +140,11 @@ module.exports = class PluginManager {
       throw new Error(`Tried to disable a non installed plugin (${pluginID})`);
     }
 
+    // Don't attempt to disable plugins twice
+    if (!this.isEnabled(pluginID)) {
+      return
+    }
+
     powercord.settings.set('disabledPlugins', [
       ...powercord.settings.get('disabledPlugins', []),
       pluginID


### PR DESCRIPTION
Currently, if a plugin is repeatedly requested to be disabled it will be added to the `disabledPlugins` array multiple times. Currently this can be seen with vpc-shiki as pc-commands is added to the array again every time Discord is restarted. This PR makes sure that a plugin is loaded before it will attempt to disabled it.