### PR TITLE
Updated changelog

### DIFF
--- a/changelogs.json
+++ b/changelogs.json
@@ -1,52 +1,88 @@
-{
-  "id": "updates-26-04-20",
-  "date": "2019-11-17",
-  "contents": [
-    {
-      "type": "HEADER",
-      "color": "GREEN",
-      "text": "Update time!",
-      "noMargin": true
-    },
-    {
-      "type": "CONTENTS",
-      "text": "It's been months since last time, so here we go with updates: Themes tab in settings is no longer useless. It's not the complete theme UI yet, this is still under construction, but you can at least apply some CSS more easily!",
-      "list": [
-        "**Quick CSS** is now a thing, in a \"Themes\" tab near you. Powered by good old CodeMirror and a bit of CSS. Yes CSS powers CSS, this is 2038 technology!!",
-        "You can **apply snippets** in Powercord's #css-snippets channels easily with a button. It'll appear in Quick CSS if you want to edit it a bit.",
-        "Quick CSS editor can be **popped out** if you want to have a handy editor to quickly test things and see changes appear live on screen."
-      ]
-    },
-    {
-      "type": "HEADER",
-      "color": "GREEN",
-      "text": "Powercord now speaks your language"
-    },
-    {
-      "type": "CONTENTS",
-      "text": "We did put some effort to make Powercord support i18n, also known as internationalization. Most of Powercord UIs should now be shown in the language you have Discord in, if translations are available. If they are not, you can [contribute](https://i18n.powercord.dev/projects/powercord) and get a sweet Translator badge on your profile!"
-    },
-    {
-      "type": "HEADER",
-      "color": "BLURPLE",
-      "text": "Other changes and fixes"
-    },
-    {
-      "type": "CONTENTS",
-      "list": [
-        "You can now **save console logs** in a file located in the `.logs` folder.",
-        "Added a top-level css class \"powercord\" if themes wants to target element only on Powercord.",
-        "Improved injection process on Linux: Powercord will now attempt to find where Discord instead of checking against a hardcoded list of paths.",
-        "Fixed **emoji utility** plugin being broke due to Discord updates.",
-        "Improved Discord's **British locale** to remove those american z. Enjoy the lang of tea even though Discord still doesn't authorise client mods. :^)",
-        "Added a few internal APIs for plugin devs. Documentation is still in the works, coming soon:tm:.",
-        "Improved ability of editors to understand how Powercord works with some JSDocs. IntelliSense ftw.",
-        "Added some **error checking** to prevent some meaningless errors from showing up in DevTools console.",
-        "**Optimized some plugins** to make them feel even more responsive and not make Discord as slow as an Electron app. Wait...",
-        "Probably a few extra things I forgot to mention.",
-        "Tuned light theme a bit so emma's cuteness is even more visible."
-      ]
-    }
-  ],
-  "footer": "Stay at home! Don't let Cowona-chan spwead out!!"
-}
+[
+  {
+    "id": "updates-ppd-number-idk",
+    "date": "2022-06-17",
+    "contents": [
+      {
+        "type": "HEADER",
+        "color": "GREEN",
+        "text": "Massive Changes!",
+        "noMargin": true
+      },
+      {
+        "type": "CONTENTS",
+        "text": "There's been some large changes in the past few months, the most notable being the addition of a proper theme manager and the integration of PowercordPluginDownloader.",
+        "list": [
+          "A **Theme manager** has been properly implemented into Powercord for enabling and disabling themes. [#634](https://github.com/powercord-org/powercord/pull/634)",
+          "**PowercordPluginDownloader** is now a part of Powercord as well. You can right click GitHub links to install the desired theme or plugin! [#654](https://github.com/powercord-org/powercord/pull/654)"
+        ]
+      },
+      {
+        "type": "HEADER",
+        "color": "BLURPLE",
+        "text": "Other changes and fixes"
+      },
+      {
+        "type": "CONTENTS",
+        "list": [
+          "You can now inject into other Discord clients (Stable and PTB), although it is **__not recommended and unsupported__**, [more info](https://github.com/powercord-org/powercord#how-can-i-install-powercord-on-stable-or-ptb).",
+          "Added **Indonesian** language.",
+          "Fixed **pc-tags** creating empty tags and crashing.",
+          "Fixed **pc-emoteUtility**. [#655](https://github.com/powercord-org/powercord/pull/655)"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "updates-26-04-20",
+    "date": "2019-11-17",
+    "contents": [
+      {
+        "type": "HEADER",
+        "color": "GREEN",
+        "text": "Update time!",
+        "noMargin": true
+      },
+      {
+        "type": "CONTENTS",
+        "text": "It's been months since last time, so here we go with updates: Themes tab in settings is no longer useless. It's not the complete theme UI yet, this is still under construction, but you can at least apply some CSS more easily!",
+        "list": [
+          "**Quick CSS** is now a thing, in a \"Themes\" tab near you. Powered by good old CodeMirror and a bit of CSS. Yes CSS powers CSS, this is 2038 technology!!",
+          "You can **apply snippets** in Powercord's #css-snippets channels easily with a button. It'll appear in Quick CSS if you want to edit it a bit.",
+          "Quick CSS editor can be **popped out** if you want to have a handy editor to quickly test things and see changes appear live on screen."
+        ]
+      },
+      {
+        "type": "HEADER",
+        "color": "GREEN",
+        "text": "Powercord now speaks your language"
+      },
+      {
+        "type": "CONTENTS",
+        "text": "We did put some effort to make Powercord support i18n, also known as internationalization. Most of Powercord UIs should now be shown in the language you have Discord in, if translations are available. If they are not, you can [contribute](https://i18n.powercord.dev/projects/powercord) and get a sweet Translator badge on your profile!"
+      },
+      {
+        "type": "HEADER",
+        "color": "BLURPLE",
+        "text": "Other changes and fixes"
+      },
+      {
+        "type": "CONTENTS",
+        "list": [
+          "You can now **save console logs** in a file located in the `.logs` folder.",
+          "Added a top-level css class \"powercord\" if themes wants to target element only on Powercord.",
+          "Improved injection process on Linux: Powercord will now attempt to find where Discord instead of checking against a hardcoded list of paths.",
+          "Fixed **emoji utility** plugin being broke due to Discord updates.",
+          "Improved Discord's **British locale** to remove those american z. Enjoy the lang of tea even though Discord still doesn't authorise client mods. :^)",
+          "Added a few internal APIs for plugin devs. Documentation is still in the works, coming soon:tm:.",
+          "Improved ability of editors to understand how Powercord works with some JSDocs. IntelliSense ftw.",
+          "Added some **error checking** to prevent some meaningless errors from showing up in DevTools console.",
+          "**Optimized some plugins** to make them feel even more responsive and not make Discord as slow as an Electron app. Wait...",
+          "Probably a few extra things I forgot to mention.",
+          "Tuned light theme a bit so emma's cuteness is even more visible."
+        ]
+      }
+    ],
+    "footer": "Stay at home! Don't let Cowona-chan spwead out!!"
+  }
+]

--- a/changelogs.json
+++ b/changelogs.json
@@ -25,7 +25,7 @@
       {
         "type": "CONTENTS",
         "list": [
-          "You can now inject into other Discord clients (Stable and PTB), although it is **__not recommended and unsupported__**, [more info](https://github.com/powercord-org/powercord#how-can-i-install-powercord-on-stable-or-ptb).",
+          "You can now inject into other Discord clients (Stable and PTB), although it is **__not recommended and unsupported__**. [More info](https://github.com/powercord-org/powercord#how-can-i-install-powercord-on-stable-or-ptb)."
           "Added **Indonesian** language.",
           "Fixed **pc-tags** creating empty tags and crashing.",
           "Fixed **pc-emoteUtility**. [#655](https://github.com/powercord-org/powercord/pull/655)"

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -10,7 +10,7 @@ const exec = promisify(cp.exec);
 
 const Settings = require('./components/Settings.jsx');
 
-const changelog = require('../../../../changelogs.json');
+const [changelog] = require('../../../../changelogs.json');
 
 module.exports = class Updater extends Plugin {
   constructor () {


### PR DESCRIPTION
This pull request updates the changelog for powercord.
The changelog file is updated to be an array rather than an object so that old changelogs are kept for whatever reason we may want them, and the first one is fetched from the file.
![image](https://user-images.githubusercontent.com/107228516/174447096-66a726f9-7d2c-4edf-a005-f55b6af2e3b5.png)
