### PR TITLE
pc-moduleManager: Add install/uninstall commands

### DIFF
--- a/src/Powercord/plugins/pc-moduleManager/commands/disable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/disable.js
@@ -1,5 +1,5 @@
 const { CORE_PLUGINS } = require('powercord/constants');
-const { resp } = require('../util/resp');
+const { resp } = require('../util');
 
 module.exports = {
   command: 'disable',

--- a/src/Powercord/plugins/pc-moduleManager/commands/disable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/disable.js
@@ -5,12 +5,12 @@ module.exports = {
   command: 'disable',
   description: 'Disable a plugin/theme',
   usage: '{c} [ plugin/theme ID ]',
-  executor([ id ]) {
+  executor ([ id ]) {
     const isPlugin = powercord.pluginManager.plugins.has(id);
     const isTheme = powercord.styleManager.themes.has(id);
 
     if (!isPlugin && !isTheme) { // No match
-      return resp(false, `Could not find plugin or theme matching "${id}".`)
+      return resp(false, `Could not find plugin or theme matching "${id}".`);
     } else if (isPlugin && isTheme) { // Duplicate name
       return resp(false, `"${id}" is in use by both a plugin and theme. You will have to disable it from settings.`);
     } else if (isPlugin && CORE_PLUGINS.includes(id)) { // Core internal plugin
@@ -19,14 +19,14 @@ module.exports = {
 
     const manager = isPlugin ? powercord.pluginManager : powercord.styleManager;
     if (!manager.isEnabled(id)) {
-      return resp(false, `"${id}" is already disabled.`)
+      return resp(false, `"${id}" is already disabled.`);
     }
 
     manager.disable(id);
     return resp(true, `${isPlugin ? 'Plugin' : 'Theme'} "${id}" disabled!`);
   },
 
-  autocomplete(args) {
+  autocomplete (args) {
     const plugins = Array.from(powercord.pluginManager.plugins.values())
       .filter(plugin =>
         !CORE_PLUGINS.includes(plugin) &&
@@ -56,7 +56,7 @@ module.exports = {
           command: theme.entityID,
           description: `Theme - ${theme.manifest.description}`
         }))
-      ],
+      ]
     };
   }
 };

--- a/src/Powercord/plugins/pc-moduleManager/commands/enable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/enable.js
@@ -4,12 +4,12 @@ module.exports = {
   command: 'enable',
   description: 'Enable a plugin/theme',
   usage: '{c} [ plugin/theme ID ]',
-  executor([ id ]) {
+  executor ([ id ]) {
     const isPlugin = powercord.pluginManager.plugins.has(id);
     const isTheme = powercord.styleManager.themes.has(id);
 
     if (!isPlugin && !isTheme) { // No match
-      return resp(false, `Could not find plugin or theme matching "${id}".`)
+      return resp(false, `Could not find plugin or theme matching "${id}".`);
     } else if (isPlugin && isTheme) { // Duplicate name
       return resp(false, `"${id}" is in use by both a plugin and theme. You will have to disable it from settings.`);
     }
@@ -23,7 +23,7 @@ module.exports = {
     return resp(true, `${isPlugin ? 'Plugin' : 'Theme'} "${id}" enabled!`);
   },
 
-  autocomplete(args) {
+  autocomplete (args) {
     if (args.length > 1) {
       return false;
     }
@@ -51,7 +51,7 @@ module.exports = {
           command: theme.entityID,
           description: `Theme - ${theme.manifest.description}`
         }))
-      ],
+      ]
     };
   }
 };

--- a/src/Powercord/plugins/pc-moduleManager/commands/enable.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/enable.js
@@ -1,4 +1,4 @@
-const { resp } = require('../util/resp');
+const { resp } = require('../util');
 
 module.exports = {
   command: 'enable',

--- a/src/Powercord/plugins/pc-moduleManager/commands/install.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/install.js
@@ -15,7 +15,6 @@ module.exports = {
     if (url?.match(/^[\w-]+\/[\w-.]+$/)) {
       url = `https://github.com/${url}`;
     }
-    console.log(url);
     try {
       new URL(url);
     } catch (e) {

--- a/src/Powercord/plugins/pc-moduleManager/commands/install.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/install.js
@@ -42,7 +42,7 @@ module.exports = {
 
     return {
       send: false,
-	  result: `Installing \`${info.repoName}\`...`
+      result: `Installing \`${info.repoName}\`...`
     };
   }
 };

--- a/src/Powercord/plugins/pc-moduleManager/commands/install.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/install.js
@@ -1,4 +1,7 @@
 const { cloneRepo, getRepoInfo } = require('../util');
+const Modal = require('../components/ConfirmModal');
+const { React } = require('powercord/webpack');
+const { open: openModal, close: closeModal } = require('powercord/modal');
 
 module.exports = {
   command: 'install',
@@ -37,12 +40,27 @@ module.exports = {
       };
     }
 
-    cloneRepo(url, powercord, info.type);
+    openModal(() => React.createElement(Modal, {
+      red: true,
+      header: `Install ${info.type}`,
+      desc: `Are you sure you want to install the ${info.type} ${info.repoName}?`,
+      onConfirm: () => {
+        cloneRepo(url, powercord, info.type);
 
-    return {
-      send: false,
-      result: `Installing \`${info.repoName}\`...`
-    };
+        powercord.api.notices.sendToast(`PDPluginInstalling-${info.repoName}`, {
+          header: `Installing ${info.repoName}...`,
+          type: 'info',
+          timeout: 10e3,
+          buttons: [ {
+            text: 'Got It',
+            color: 'green',
+            size: 'medium',
+            look: 'outlined'
+          } ]
+        });
+      },
+      onCancel: () => closeModal()
+    }));
   }
 };
 

--- a/src/Powercord/plugins/pc-moduleManager/commands/install.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/install.js
@@ -1,5 +1,4 @@
-const { getRepoInfo } = require('../getinfo');
-const cloneRepo = require('../util/cloneRepo');
+const { cloneRepo, getRepoInfo } = require('../util');
 
 module.exports = {
   command: 'install',

--- a/src/Powercord/plugins/pc-moduleManager/commands/install.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/install.js
@@ -1,0 +1,49 @@
+const { getRepoInfo } = require('../getinfo');
+const cloneRepo = require('../util/cloneRepo');
+
+module.exports = {
+  command: 'install',
+  description: 'Install a plugin or theme.',
+  usage: '{c} [ plugin URL ]',
+  async executor (args) {
+    let url = args[0];
+    if (url) {
+      url = url.trim();
+    }
+    if (url?.match(/^[\w-]+\/[\w-.]+$/)) {
+      url = `https://github.com/${url}`;
+    }
+    console.log(url);
+    try {
+      new URL(url);
+    } catch (e) {
+      return {
+        send: false,
+        result: 'Invalid URL! Please specify a valid GitHub URL or username/repository.'
+      };
+    }
+
+    const info = await getRepoInfo(url);
+    if (!info) {
+      return {
+        send: false,
+        result: 'The requested plugin or theme could not be found or is invalid.'
+      };
+    }
+
+    if (info.isInstalled) {
+      return {
+        send: false,
+        result: `\`${info.repoName}\` is already installed!`
+      };
+    }
+
+    cloneRepo(url, powercord, info.type);
+
+    return {
+      send: false,
+	  result: `Installing \`${info.repoName}\`...`
+    };
+  }
+};
+

--- a/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
@@ -2,73 +2,79 @@ const Modal = require('../components/ConfirmModal');
 const { React } = require('powercord/webpack');
 const { open: openModal, close: closeModal } = require('powercord/modal');
 
+const { resp } = require('../util/resp');
+
 module.exports = {
   command: 'uninstall',
-  description: 'Uninstall a selected plugin and delete the files.',
-  usage: '{c} [ plugin ID ]',
-  executor (args) {
-    let result;
+  description: 'Uninstall a plugin/theme',
+  usage: '{c} [ plugin/theme ID ]',
+  executor ([ id ]) {
+    const isPlugin = powercord.pluginManager.plugins.has(id);
+    const isTheme = powercord.styleManager.themes.has(id);
 
-    if (powercord.pluginManager.plugins.has(args[0])) {
-      if (args[0].startsWith('pc-')) {
-        result = `->> ERROR: You cannot uninstall an internal plugin!
-            (Tried to unload ${args[0]})`;
-      } else {
-        openModal(() => React.createElement(Modal, {
-          red: true,
-          header: `Uninstall ${args[0]}`,
-          desc: `Are you sure you want to uninstall and delete ${args[0]}? This cannot be undone.`,
-          onConfirm: () => {
-            powercord.pluginManager.uninstall(args[0]);
-
-            powercord.api.notices.sendToast(`PDPluginUninstalled-${args[0]}`, {
-              header: 'Plugin Uninstalled',
-              content: `${args[0]} uninstalled and deleted`,
-              type: 'info',
-              timeout: 10e3,
-              buttons: [ {
-                text: 'Got It',
-                color: 'green',
-                size: 'medium',
-                look: 'outlined'
-              } ]
-            });
-          },
-          onCancel: () => closeModal()
-        }));
-      }
-      return {
-        send: false
-      };
+    if (!isPlugin && !isTheme) { // No match
+      return resp(false, `Could not find plugin or theme matching "${id}".`);
+    } else if (isPlugin && isTheme) { // Duplicate name
+      return resp(false, `"${id}" is in use by both a plugin and theme. You will have to uninstall it from settings.`);
+    } else if (isPlugin && id.startsWith('pc-')) { // Internal plugin
+      return resp(false, `"${id}" provides core functionality and cannot be uninstalled.`);
     }
-    result = `->> ERROR: Tried to disable a non-installed plugin!
-          (${args[0]})`;
+
+    const manager = isPlugin ? powercord.pluginManager : powercord.styleManager;
 
 
-    return {
-      send: false,
-      result: `\`\`\`diff\n${result}\`\`\``
-    };
+    openModal(() => React.createElement(Modal, {
+      red: true,
+      header: `Uninstall ${id}`,
+      desc: `Are you sure you want to uninstall and delete ${id}? This cannot be undone.`,
+      onConfirm: () => {
+        manager.uninstall(id);
+
+        powercord.api.notices.sendToast(`PDPluginUninstalled-${id}`, {
+          header: `${isPlugin ? 'Plugin' : 'Theme'} Uninstalled`,
+          content: `${id} uninstalled and deleted`,
+          type: 'info',
+          timeout: 10e3,
+          buttons: [ {
+            text: 'Got It',
+            color: 'green',
+            size: 'medium',
+            look: 'outlined'
+          } ]
+        });
+      },
+      onCancel: () => closeModal()
+    }));
   },
 
   autocomplete (args) {
-    const plugins = powercord.pluginManager.getPlugins()
-      .sort((a, b) => a - b)
-      .map(plugin => powercord.pluginManager.plugins.get(plugin));
+    const plugins = Array.from(powercord.pluginManager.plugins.values())
+      .filter(plugin =>
+        !plugin.entityID.startsWith('pc-') &&
+        plugin.entityID.toLowerCase().includes(args[0]?.toLowerCase())
+      );
+
+    const themes = Array.from(powercord.styleManager.themes.values())
+      .filter(theme =>
+        theme.entityID.toLowerCase().includes(args[0]?.toLowerCase())
+      );
 
     if (args.length > 1) {
       return false;
     }
 
     return {
-      commands: plugins
-        .filter(plugin => plugin.entityID !== 'pc-commands' &&
-          plugin.entityID.toLowerCase().includes(args[0] && args[0].toLowerCase()))
-        .map(plugin => ({
+      header: 'powercord entities list',
+      commands: [
+        ...plugins.map(plugin => ({
           command: plugin.entityID,
-          description: plugin.manifest.description
+          description: `Plugin - ${plugin.manifest.description}`
         })),
-      header: 'powercord plugin list'
+        ...themes.map(theme => ({
+          command: theme.entityID,
+          description: `Theme - ${theme.manifest.description}`
+        }))
+      ]
     };
   }
 };

--- a/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
@@ -1,3 +1,7 @@
+const Modal = require('../components/ConfirmModal');
+const { React } = require('powercord/webpack');
+const { open: openModal, close: closeModal } = require('powercord/modal');
+
 module.exports = {
   command: 'uninstall',
   description: 'Uninstall a selected plugin and delete the files.',
@@ -10,14 +14,36 @@ module.exports = {
         result = `->> ERROR: You cannot uninstall an internal plugin!
             (Tried to unload ${args[0]})`;
       } else {
-        powercord.pluginManager.uninstall(args[0]);
-        result = `+>> SUCCESS: Plugin uninstall!
-            (${args[0]})`;
+        openModal(() => React.createElement(Modal, {
+          red: true,
+          header: `Uninstall ${args[0]}`,
+          desc: `Are you sure you want to uninstall and delete ${args[0]}? This cannot be undone.`,
+          onConfirm: () => {
+            powercord.pluginManager.uninstall(args[0]);
+
+            powercord.api.notices.sendToast(`PDPluginUninstalled-${args[0]}`, {
+              header: 'Plugin Uninstalled',
+              content: `${args[0]} uninstalled and deleted`,
+              type: 'info',
+              timeout: 10e3,
+              buttons: [ {
+                text: 'Got It',
+                color: 'green',
+                size: 'medium',
+                look: 'outlined'
+              } ]
+            });
+          },
+          onCancel: () => closeModal()
+        }));
       }
-    } else {
-      result = `->> ERROR: Tried to disable a non-installed plugin!
-          (${args[0]})`;
+      return {
+        send: false
+      };
     }
+    result = `->> ERROR: Tried to disable a non-installed plugin!
+          (${args[0]})`;
+
 
     return {
       send: false,

--- a/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
+++ b/src/Powercord/plugins/pc-moduleManager/commands/uninstall.js
@@ -1,0 +1,48 @@
+module.exports = {
+  command: 'uninstall',
+  description: 'Uninstall a selected plugin and delete the files.',
+  usage: '{c} [ plugin ID ]',
+  executor (args) {
+    let result;
+
+    if (powercord.pluginManager.plugins.has(args[0])) {
+      if (args[0].startsWith('pc-')) {
+        result = `->> ERROR: You cannot uninstall an internal plugin!
+            (Tried to unload ${args[0]})`;
+      } else {
+        powercord.pluginManager.uninstall(args[0]);
+        result = `+>> SUCCESS: Plugin uninstall!
+            (${args[0]})`;
+      }
+    } else {
+      result = `->> ERROR: Tried to disable a non-installed plugin!
+          (${args[0]})`;
+    }
+
+    return {
+      send: false,
+      result: `\`\`\`diff\n${result}\`\`\``
+    };
+  },
+
+  autocomplete (args) {
+    const plugins = powercord.pluginManager.getPlugins()
+      .sort((a, b) => a - b)
+      .map(plugin => powercord.pluginManager.plugins.get(plugin));
+
+    if (args.length > 1) {
+      return false;
+    }
+
+    return {
+      commands: plugins
+        .filter(plugin => plugin.entityID !== 'pc-commands' &&
+          plugin.entityID.toLowerCase().includes(args[0] && args[0].toLowerCase()))
+        .map(plugin => ({
+          command: plugin.entityID,
+          description: plugin.manifest.description
+        })),
+      header: 'powercord plugin list'
+    };
+  }
+};

--- a/src/Powercord/plugins/pc-moduleManager/components/ConfirmModal.jsx
+++ b/src/Powercord/plugins/pc-moduleManager/components/ConfirmModal.jsx
@@ -1,0 +1,31 @@
+const { React } = require('powercord/webpack');
+const { Confirm } = require('powercord/components/modal');
+const {
+  Text
+} = require('powercord/components');
+const { close: closeModal } = require('powercord/modal');
+
+let setting;
+
+module.exports = class Modal extends React.Component {
+  render () {
+    if (this.options && this.options.setting) {
+      ({ setting } = this.options);
+
+      if (!setting.default) {
+        setting.default = '';
+      }
+    }
+
+    return <Confirm
+      red={this.props.red || false}
+      header={this.props.header || null}
+      confirmText={this.props.confirmText || 'Confirm'}
+      cancelText={this.props.cancelText || 'Cancel'}
+      onConfirm={() => this.props.onConfirm()}
+      onCancel={() => typeof this.props.onCancel !== 'undefined' ? this.props.onCancel() : closeModal()}
+    >
+      <Text>{this.props.desc}</Text>
+    </Confirm>;
+  }
+};

--- a/src/Powercord/plugins/pc-moduleManager/getinfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/getinfo.js
@@ -1,0 +1,88 @@
+// @ts-check
+
+const { get } = require('powercord/http');
+
+/**
+ * @type Map<string, 'plugin'|'theme'|null>
+ */
+const typeCache = new Map();
+
+/**
+ * @typedef PluginInfo
+ * @property {string} username
+ * @property {string} repoName
+ * @property {'plugin'|'theme'} type Whether the URL is a plugin or theme repository
+ * @property {boolean} isInstalled Whether the plugin/theme is installed
+ */
+
+/**
+ *
+ * @param {string} identifier username/reponame
+ * @returns {Promise<'plugin'|'theme'|null>} Whether the URL is a plugin or theme repository, or null if it's neither
+ */
+async function getRepoType (identifier) {
+  if (typeCache.has(identifier)) {
+    return typeCache.get(identifier);
+  }
+
+
+  const isPlugin = get(`https://github.com/${identifier}/raw/HEAD/manifest.json`).then((r) => {
+    if (r?.statusCode === 302) {
+      return 'plugin';
+    }
+    throw null;
+  }).catch(() => null);
+
+  const isTheme = get(`https://github.com/${identifier}/raw/HEAD/powercord_manifest.json`).then((r) => {
+    if (r?.statusCode === 302) {
+      return 'theme';
+    }
+    throw null;
+  }).catch(() => null);
+
+  // Wait for either promise to resolve
+  // If neither resolves, use null.
+
+  // @ts-ignore
+  const type = await Promise.any([ isPlugin, isTheme ]).catch(() => null);
+
+  typeCache.set(identifier, type);
+  return type;
+}
+
+/**
+ * Check if a URL is a plugin or theme repository
+ * @param {string} url The URL to check
+ * @returns {Promise<PluginInfo|null>}
+ */
+async function getRepoInfo (url) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (e) {
+    return null;
+  }
+
+  const isGithub = parsedUrl.hostname.split('.').slice(-2).join('.') === 'github.com';
+  const [ , username, repoName ] = parsedUrl.pathname.split('/');
+  if (!isGithub || !username || !repoName) {
+    return null;
+  }
+  const identifier = `${username}/${repoName}`;
+  const type = await getRepoType(identifier);
+  if (!type) {
+    return null;
+  }
+
+  // @ts-ignore
+  const isInstalled = type === 'plugin' ? powercord.pluginManager.isInstalled(repoName) : powercord.styleManager.isInstalled(repoName);
+
+  return {
+    username,
+    repoName,
+    type,
+    isInstalled
+  };
+}
+
+module.exports = { getRepoInfo };

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -3,7 +3,7 @@ const { writeFile, readFile } = require('fs').promises;
 const { React, getModule, i18n: { Messages } } = require('powercord/webpack');
 const { PopoutWindow } = require('powercord/components');
 const { inject, uninject } = require('powercord/injector');
-const { findInReactTree } = require('powercord/util');
+const { findInReactTree, forceUpdateElement } = require('powercord/util');
 const { Plugin } = require('powercord/entities');
 const { SpecialChannels: { CSS_SNIPPETS } } = require('powercord/constants');
 const { join } = require('path');
@@ -119,7 +119,7 @@ module.exports = class ModuleManager extends Plugin {
       const info = getRepoInfo(target.href);
       if (info instanceof Promise) {
         info.then(info => {
-          res = this._addContextMenu(res, info, target.href);
+          this._addContextMenu(res, info, target.href);
         });
       } else {
         this._addContextMenu(res, info, target.href);
@@ -164,7 +164,7 @@ module.exports = class ModuleManager extends Plugin {
       );
     }
 
-    return res;
+    forceUpdateElement('#message');
   }
 
   async _injectSnippets () {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -110,50 +110,57 @@ module.exports = class ModuleManager extends Plugin {
   }
 
   async _installerInjectCtxMenu () {
-    const menu = await getModule([ 'MenuItem' ]);
-
     injectContextMenu('pc-installer-ctx-menu', 'MessageContextMenu', ([ { target } ], res) => {
       if (!target || !target?.href || !target?.tagName || target.tagName.toLowerCase() !== 'a') {
         return res;
       }
 
-      getRepoInfo(target.href).then(info => {
-        if (!info) {
-          return;
-        }
-        const { type, isInstalled } = info;
-
-        const label = type === 'plugin' ? 'Plugin' : 'Theme';
-
-        if (isInstalled) {
-          res.props.children.splice(
-            4,
-            0,
-            React.createElement(menu.MenuItem, {
-              name: `${label} Installed`,
-              seperate: true,
-              id: 'InstallerContextLink',
-              label: `${label} Installed`,
-              action: () => console.log('lol what it\'s already installed idiot')
-            })
-          );
-        } else {
-          res.props.children.splice(
-            4,
-            0,
-            React.createElement(menu.MenuItem, {
-              name: `Install ${label}`,
-              seperate: true,
-              id: 'InstallerContextLink',
-              label: `Install ${label}`,
-              action: () => cloneRepo(target.href, powercord, type)
-            })
-          );
-        }
-      });
+      const info = getRepoInfo(target.href);
+      if (info instanceof Promise) {
+        info.then(info => this._addContextMenu(res, info, target.href));
+      } else {
+        this._addContextMenu(res, info, target.href);
+      }
 
       return res;
     });
+  }
+
+  _addContextMenu (res, info, url) {
+    const menu = getModule([ 'MenuItem' ], false);
+
+    if (!info) {
+      return;
+    }
+    const { type, isInstalled } = info;
+
+    const label = type === 'plugin' ? 'Plugin' : 'Theme';
+
+    if (isInstalled) {
+      res.props.children.splice(
+        4,
+        0,
+        React.createElement(menu.MenuItem, {
+          name: `${label} Installed`,
+          seperate: true,
+          id: 'InstallerContextLink',
+          label: `${label} Installed`,
+          action: () => console.log('lol what it\'s already installed idiot')
+        })
+      );
+    } else {
+      res.props.children.splice(
+        4,
+        0,
+        React.createElement(menu.MenuItem, {
+          name: `Install ${label}`,
+          seperate: true,
+          id: 'InstallerContextLink',
+          label: `Install ${label}`,
+          action: () => cloneRepo(url, powercord, type)
+        })
+      );
+    }
   }
 
   async _injectSnippets () {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -118,53 +118,41 @@ module.exports = class ModuleManager extends Plugin {
 
       const info = getRepoInfo(target.href);
       if (info instanceof Promise) {
-        info.then(info => {
-          this._addContextMenu(res, info, target.href);
-        });
-      } else {
-        this._addContextMenu(res, info, target.href);
+        info.then(() => forceUpdateElement('#message'));
+      } else if (info) {
+        const { type, isInstalled } = info;
+
+        const label = type === 'plugin' ? 'Plugin' : 'Theme';
+
+        if (isInstalled) {
+          res.props.children.splice(
+            4,
+            0,
+            React.createElement(this.Menu.MenuItem, {
+              name: `${label} Installed`,
+              seperate: true,
+              id: 'InstallerContextLink',
+              label: `${label} Installed`,
+              action: () => console.log('lol what it\'s already installed idiot')
+            })
+          );
+        } else {
+          res.props.children.splice(
+            4,
+            0,
+            React.createElement(this.Menu.MenuItem, {
+              name: `Install ${label}`,
+              seperate: true,
+              id: 'InstallerContextLink',
+              label: `Install ${label}`,
+              action: () => cloneRepo(target.href, powercord, type)
+            })
+          );
+        }
       }
 
       return res;
     });
-  }
-
-  _addContextMenu (res, info, url) {
-    if (!info) {
-      return;
-    }
-
-    const { type, isInstalled } = info;
-
-    const label = type === 'plugin' ? 'Plugin' : 'Theme';
-
-    if (isInstalled) {
-      res.props.children.splice(
-        4,
-        0,
-        React.createElement(this.Menu.MenuItem, {
-          name: `${label} Installed`,
-          seperate: true,
-          id: 'InstallerContextLink',
-          label: `${label} Installed`,
-          action: () => console.log('lol what it\'s already installed idiot')
-        })
-      );
-    } else {
-      res.props.children.splice(
-        4,
-        0,
-        React.createElement(this.Menu.MenuItem, {
-          name: `Install ${label}`,
-          seperate: true,
-          id: 'InstallerContextLink',
-          label: `Install ${label}`,
-          action: () => cloneRepo(url, powercord, type)
-        })
-      );
-    }
-
-    forceUpdateElement('#message');
   }
 
   async _injectSnippets () {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -24,6 +24,7 @@ module.exports = class ModuleManager extends Plugin {
   async startPlugin () {
     powercord.api.i18n.loadAllStrings(i18n);
     Object.values(commands).forEach(cmd => powercord.api.commands.registerCommand(cmd));
+    this.Menu = getModule([ 'MenuItem' ], false);
 
     powercord.api.labs.registerExperiment({
       id: 'pc-moduleManager-themes2',
@@ -117,7 +118,9 @@ module.exports = class ModuleManager extends Plugin {
 
       const info = getRepoInfo(target.href);
       if (info instanceof Promise) {
-        info.then(info => this._addContextMenu(res, info, target.href));
+        info.then(info => {
+          res = this._addContextMenu(res, info, target.href);
+        });
       } else {
         this._addContextMenu(res, info, target.href);
       }
@@ -127,11 +130,10 @@ module.exports = class ModuleManager extends Plugin {
   }
 
   _addContextMenu (res, info, url) {
-    const menu = getModule([ 'MenuItem' ], false);
-
     if (!info) {
       return;
     }
+
     const { type, isInstalled } = info;
 
     const label = type === 'plugin' ? 'Plugin' : 'Theme';
@@ -140,7 +142,7 @@ module.exports = class ModuleManager extends Plugin {
       res.props.children.splice(
         4,
         0,
-        React.createElement(menu.MenuItem, {
+        React.createElement(this.Menu.MenuItem, {
           name: `${label} Installed`,
           seperate: true,
           id: 'InstallerContextLink',
@@ -152,7 +154,7 @@ module.exports = class ModuleManager extends Plugin {
       res.props.children.splice(
         4,
         0,
-        React.createElement(menu.MenuItem, {
+        React.createElement(this.Menu.MenuItem, {
           name: `Install ${label}`,
           seperate: true,
           id: 'InstallerContextLink',
@@ -161,6 +163,8 @@ module.exports = class ModuleManager extends Plugin {
         })
       );
     }
+
+    return res;
   }
 
   async _injectSnippets () {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -16,9 +16,8 @@ const Themes = require('./components/manage/Themes');
 const QuickCSS = require('./components/manage/QuickCSS');
 const SnippetButton = require('./components/SnippetButton');
 const InstallerButton = require('./components/installer/Button');
-const cloneRepo = require('./util/cloneRepo');
+const { cloneRepo, getRepoInfo } = require('./util');
 const { injectContextMenu } = require('powercord/util');
-const { getRepoInfo } = require('./getinfo');
 
 // @todo: give a look to why quickcss.css file shits itself
 module.exports = class ModuleManager extends Plugin {

--- a/src/Powercord/plugins/pc-moduleManager/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/index.js
@@ -7,7 +7,6 @@ const { findInReactTree } = require('powercord/util');
 const { Plugin } = require('powercord/entities');
 const { SpecialChannels: { CSS_SNIPPETS } } = require('powercord/constants');
 const { join } = require('path');
-const { get } = require('powercord/http');
 const commands = require('./commands');
 const deeplinks = require('./deeplinks');
 const i18n = require('./licenses/index');
@@ -19,6 +18,7 @@ const SnippetButton = require('./components/SnippetButton');
 const InstallerButton = require('./components/installer/Button');
 const cloneRepo = require('./util/cloneRepo');
 const { injectContextMenu } = require('powercord/util');
+const { getRepoInfo } = require('./getinfo');
 
 // @todo: give a look to why quickcss.css file shits itself
 module.exports = class ModuleManager extends Plugin {
@@ -113,102 +113,50 @@ module.exports = class ModuleManager extends Plugin {
   async _installerInjectCtxMenu () {
     const menu = await getModule([ 'MenuItem' ]);
 
-    const typeCache = new Map(); // { isTheme: false, isPlugin: false}
-
     injectContextMenu('pc-installer-ctx-menu', 'MessageContextMenu', ([ { target } ], res) => {
       if (!target || !target?.href || !target?.tagName || target.tagName.toLowerCase() !== 'a') {
         return res;
       }
 
-      const parsedUrl = new URL(target.href);
-      const isGithub = parsedUrl.hostname.split('.').slice(-2).join('.') === 'github.com';
-      const [ , username, repoName ] = parsedUrl.pathname.split('/');
-
-      if (isGithub && username && repoName) {
-        if (typeCache.get(`${username}/${repoName}`) !== undefined) {
-          if (typeCache.get(`${username}/${repoName}`).isPlugin) {
-            if (powercord.pluginManager.isInstalled(repoName)) {
-              res.props.children.splice(
-                4,
-                0,
-                React.createElement(menu.MenuItem, {
-                  name: 'Plugin Installed',
-                  seperate: true,
-                  id: 'InstallerContextLink',
-                  label: 'Plugin Installed',
-                  action: () => console.log('lol what it\'s already installed idiot')
-                })
-              );
-            } else {
-              res.props.children.splice(
-                4,
-                0,
-                React.createElement(menu.MenuItem, {
-                  name: 'Install Plugin',
-                  seperate: true,
-                  id: 'InstallerContextLink',
-                  label: 'Install Plugin',
-                  action: () => cloneRepo(target.href, powercord, 'plugin')
-                })
-              );
-            }
-          } else if (typeCache.get(`${username}/${repoName}`).isTheme) {
-            if (powercord.styleManager.isInstalled(repoName)) {
-              res.props.children.splice(4, 0, React.createElement(menu.MenuItem, {
-                name: 'Theme Installed',
-                seperate: true,
-                id: 'DownloaderContextLink',
-                label: 'Theme Installed',
-                action: () => console.log('lol what it\'s already installed idiot')
-              }));
-            } else {
-              res.props.children.splice(4, 0, React.createElement(menu.MenuItem, {
-                name: 'Install Theme',
-                seperate: true,
-                id: 'DownloaderContextLink',
-                label: 'Install Theme',
-                action: () => cloneRepo(target.href, powercord, 'theme')
-              }));
-            }
-          }
-        } else {
-          get(`https://github.com/${username}/${repoName}/raw/HEAD/powercord_manifest.json`).then((r) => {
-            if (r?.statusCode === 302) {
-              typeCache.set(`${username}/${repoName}`, { isTheme: true });
-              res.props.children.splice(4, 0, React.createElement(menu.MenuItem, {
-                name: 'Install Theme',
-                seperate: true,
-                id: 'DownloaderContextLink',
-                label: 'Install Theme',
-                action: () => cloneRepo(target.href, powercord, 'theme')
-              }));
-            }
-          }).catch(() => {});
-
-
-          get(`https://github.com/${username}/${repoName}/raw/HEAD/manifest.json`).then((r) => {
-            if (r?.statusCode === 302) {
-              typeCache.set(`${username}/${repoName}`, { isPlugin: true });
-              res.props.children.splice(
-                4,
-                0,
-                React.createElement(menu.MenuItem, {
-                  name: 'Install Plugin',
-                  seperate: true,
-                  id: 'InstallerContextLink',
-                  label: 'Install Plugin',
-                  action: () => cloneRepo(target.href, powercord, 'plugin')
-                })
-              );
-            }
-          }).catch(() => {});
+      getRepoInfo(target.href).then(info => {
+        if (!info) {
+          return;
         }
-      }
+        const { type, isInstalled } = info;
+
+        const label = type === 'plugin' ? 'Plugin' : 'Theme';
+
+        if (isInstalled) {
+          res.props.children.splice(
+            4,
+            0,
+            React.createElement(menu.MenuItem, {
+              name: `${label} Installed`,
+              seperate: true,
+              id: 'InstallerContextLink',
+              label: `${label} Installed`,
+              action: () => console.log('lol what it\'s already installed idiot')
+            })
+          );
+        } else {
+          res.props.children.splice(
+            4,
+            0,
+            React.createElement(menu.MenuItem, {
+              name: `Install ${label}`,
+              seperate: true,
+              id: 'InstallerContextLink',
+              label: `Install ${label}`,
+              action: () => cloneRepo(target.href, powercord, type)
+            })
+          );
+        }
+      });
 
       return res;
     });
   }
-  
+
   async _injectSnippets () {
     const MiniPopover = await getModule(m => m.default && m.default.displayName === 'MiniPopover');
     inject('pc-moduleManager-snippets', MiniPopover, 'default', (args, res) => {

--- a/src/Powercord/plugins/pc-moduleManager/util/cloneRepo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/cloneRepo.js
@@ -32,7 +32,7 @@ module.exports = async function download (url, powercord, type) {
     console.log(data);
 
     if (data.includes('already exists')) {
-      powercord.api.notices.sendToast(`PDAlreadyInstalled-${Math.floor(Math.random() * 999)}`, {
+      powercord.api.notices.sendToast(`PDAlreadyInstalled-${repoName}`, {
         header: 'Plugin Already Installed',
         content: `${repoName} is already installed.`,
         type: 'info',
@@ -58,10 +58,11 @@ module.exports = async function download (url, powercord, type) {
       }
 
       if (files.includes('powercord_manifest.json') || files.includes('manifest.json')) {
+        powercord.api.notices.closeToast(`PDPluginInstalling-${repoName}`);
         if (type === 'plugin') {
           await powercord.pluginManager.remount(repoName);
           if (powercord.pluginManager.plugins.has(repoName)) {
-            powercord.api.notices.sendToast(`PDPluginInstalled-${Math.floor(Math.random() * 999)}`, {
+            powercord.api.notices.sendToast(`PDPluginInstalled-${repoName}`, {
               header: 'Plugin Installed',
               content: `${repoName} installed`,
               type: 'info',
@@ -79,7 +80,7 @@ module.exports = async function download (url, powercord, type) {
         } else if (type === 'theme') {
           await powercord.styleManager.loadThemes();
           if (powercord.styleManager.themes.has(repoName)) {
-            powercord.api.notices.sendToast(`PDPluginInstalled-${Math.floor(Math.random() * 999)}`, {
+            powercord.api.notices.sendToast(`PDPluginInstalled-${repoName}`, {
               header: 'Theme Installed',
               content: `${repoName} installed`,
               type: 'info',

--- a/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
@@ -21,25 +21,25 @@ const typeCache = new Map();
  * @returns {Promise<'plugin'|'theme'|null>} Whether the URL is a plugin or theme repository, or null if it's neither
  */
 async function getRepoType (identifier) {
-  const isTheme = get(`https://github.com/${identifier}/raw/HEAD/powercord_manifest.json`).then((r) => {
+  const isTheme = await get(`https://github.com/${identifier}/raw/HEAD/powercord_manifest.json`).then((r) => {
     if (r?.statusCode === 302) {
       return 'theme';
     }
-    throw null;
+    return null;
   }).catch(() => null);
 
 
-  const isPlugin = get(`https://github.com/${identifier}/raw/HEAD/manifest.json`).then((r) => {
+  const isPlugin = await get(`https://github.com/${identifier}/raw/HEAD/manifest.json`).then((r) => {
     if (r?.statusCode === 302) {
       return 'plugin';
     }
-    throw null;
+    return null;
   }).catch(() => null);
   // Wait for either promise to resolve
   // If neither resolves, use null.
 
   // @ts-ignore
-  const type = await Promise.any([ isTheme, isPlugin ]).catch(() => null);
+  const type = isTheme || isPlugin || null;
 
   typeCache.set(identifier, type);
   return type;

--- a/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
@@ -78,14 +78,23 @@ module.exports = function getRepoInfo (url) {
   };
 
   if (typeCache.has(identifier)) {
+    const type = typeCache.get(identifier);
+    if (!type) {
+      return null;
+    }
     return {
       ...data,
-      type: typeCache.get(identifier)
+      type
     };
   }
 
-  return getRepoType(identifier).then(type => ({
-    ...data,
-    type
-  }));
+  return getRepoType(identifier).then(type => {
+    if (!type) {
+      return null;
+    }
+    return {
+      ...data,
+      type
+    };
+  });
 };

--- a/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
@@ -21,13 +21,6 @@ const typeCache = new Map();
  * @returns {Promise<'plugin'|'theme'|null>} Whether the URL is a plugin or theme repository, or null if it's neither
  */
 async function getRepoType (identifier) {
-  const isPlugin = get(`https://github.com/${identifier}/raw/HEAD/manifest.json`).then((r) => {
-    if (r?.statusCode === 302) {
-      return 'plugin';
-    }
-    throw null;
-  }).catch(() => null);
-
   const isTheme = get(`https://github.com/${identifier}/raw/HEAD/powercord_manifest.json`).then((r) => {
     if (r?.statusCode === 302) {
       return 'theme';
@@ -35,11 +28,18 @@ async function getRepoType (identifier) {
     throw null;
   }).catch(() => null);
 
+
+  const isPlugin = get(`https://github.com/${identifier}/raw/HEAD/manifest.json`).then((r) => {
+    if (r?.statusCode === 302) {
+      return 'plugin';
+    }
+    throw null;
+  }).catch(() => null);
   // Wait for either promise to resolve
   // If neither resolves, use null.
 
   // @ts-ignore
-  const type = await Promise.any([ isPlugin, isTheme ]).catch(() => null);
+  const type = await Promise.any([ isTheme, isPlugin ]).catch(() => null);
 
   typeCache.set(identifier, type);
   return type;

--- a/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/getInfo.js
@@ -55,7 +55,7 @@ async function getRepoType (identifier) {
  * @param {string} url The URL to check
  * @returns {Promise<PluginInfo|null>}
  */
-async function getRepoInfo (url) {
+module.exports = async function getRepoInfo (url) {
   let parsedUrl;
   try {
     parsedUrl = new URL(url);
@@ -83,6 +83,4 @@ async function getRepoInfo (url) {
     type,
     isInstalled
   };
-}
-
-module.exports = { getRepoInfo };
+};

--- a/src/Powercord/plugins/pc-moduleManager/util/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/index.js
@@ -1,7 +1,9 @@
 const getRepoInfo = require('./getInfo');
 const cloneRepo = require('./cloneRepo');
+const { resp } = require('./resp');
 
 module.exports = {
   getRepoInfo,
-  cloneRepo
+  cloneRepo,
+  resp
 };

--- a/src/Powercord/plugins/pc-moduleManager/util/index.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/index.js
@@ -1,0 +1,7 @@
+const getRepoInfo = require('./getInfo');
+const cloneRepo = require('./cloneRepo');
+
+module.exports = {
+  getRepoInfo,
+  cloneRepo
+};

--- a/src/Powercord/plugins/pc-moduleManager/util/resp.js
+++ b/src/Powercord/plugins/pc-moduleManager/util/resp.js
@@ -4,6 +4,6 @@ exports.resp = (success, description) => ({
     type: 'rich',
     color: success ? 0x1bbb1b : 0xdd2d2d,
     title: success ? 'Success' : 'Error',
-    description,
-  },
+    description
+  }
 });

--- a/src/fake_node_modules/powercord/http/GenericRequest.js
+++ b/src/fake_node_modules/powercord/http/GenericRequest.js
@@ -162,8 +162,8 @@ class GenericRequest {
 
   /**
    * Executes the request and attaches success and/or error handler
-   * @param {function({HTTPResponse})} resolver Success handler
-   * @param {function({HTTPError})|null} rejector Error handler
+   * @param {function(HTTPResponse)} resolver Success handler
+   * @param {function(HTTPError)|null} [rejector] Error handler
    * @returns {Promise<HTTPResponse>}
    */
   then (resolver, rejector) {
@@ -178,7 +178,7 @@ class GenericRequest {
 
   /**
    * Executes the requests and attaches an error handler
-   * @param {function({HTTPError})|null} rejector Error handler
+   * @param {function(HTTPError)|null} [rejector] Error handler
    * @returns {Promise<HTTPResponse>}
    */
   catch (rejector) {


### PR DESCRIPTION
- Move code to get repo info to own file and refactor link context menu accordingly
- Add command to install plugin or theme. Takes either a GitHub link or `username/reponame` as an argument.
- Add command to uninstall plugin or theme.