### PR TITLE
pc-updater: fix when not on branch

### DIFF
--- a/src/Powercord/index.js
+++ b/src/Powercord/index.js
@@ -31,8 +31,8 @@ let coremods;
 
 /**
  * @typedef GitInfos
- * @property {String} upstream
- * @property {String} branch
+ * @property {String | null} upstream
+ * @property {String | null} branch
  * @property {String} revision
  */
 

--- a/src/Powercord/plugins/pc-updater/components/Settings.jsx
+++ b/src/Powercord/plugins/pc-updater/components/Settings.jsx
@@ -83,7 +83,7 @@ module.exports = class UpdaterSettings extends React.PureComponent {
         <div className="about">
           <div>
             <span>{Messages.POWERCORD_UPDATES_UPSTREAM}</span>
-            <span>{powercord.gitInfos.upstream.replace(REPO_URL, Messages.POWERCORD_UPDATES_UPSTREAM_OFFICIAL)}</span>
+            <span>{(powercord.gitInfos.upstream || 'none').replace(REPO_URL, Messages.POWERCORD_UPDATES_UPSTREAM_OFFICIAL)}</span>
           </div>
           <div>
             <span>{Messages.POWERCORD_UPDATES_REVISION}</span>
@@ -91,7 +91,7 @@ module.exports = class UpdaterSettings extends React.PureComponent {
           </div>
           <div>
             <span>{Messages.POWERCORD_UPDATES_BRANCH}</span>
-            <span>{powercord.gitInfos.branch}</span>
+            <span>{powercord.gitInfos.branch || 'none'}</span>
           </div>
         </div>
       </div>
@@ -397,16 +397,18 @@ module.exports = class UpdaterSettings extends React.PureComponent {
 
           <b>Git </b>
           <div className='row'>
-            <div className='column'>Upstream:&#10;{powercord.gitInfos.upstream.replace(REPO_URL, 'Official')}</div>
+            <div className='column'>Upstream:&#10;{(powercord.gitInfos.upstream || 'none').replace(REPO_URL, 'Official')}</div>
             <div className='column'>Revision:&#10;
-              <a
-                href={`https://github.com/${powercord.gitInfos.upstream}/commit/${powercord.gitInfos.revision}`}
-                target='_blank'
-              >
+              {powercord.gitInfos.upstream
+                ? <a
+                  href={`https://github.com/${powercord.gitInfos.upstream}/commit/${powercord.gitInfos.revision}`}
+                  target='_blank'
+                >
                 [{powercord.gitInfos.revision.substring(0, 7)}]
-              </a>
+                </a>
+                : powercord.gitInfos.revision.substring(0, 7)}
             </div>
-            <div className='column'>Branch:&#10;{powercord.gitInfos.branch}</div>
+            <div className='column'>Branch:&#10;{powercord.gitInfos.branch || 'none'}</div>
             <div className='column'>{`Latest:\n${!this.props.getSetting('updates', []).find(update => update.id === 'powercord')}`}</div>
           </div>
 

--- a/src/Powercord/plugins/pc-updater/index.js
+++ b/src/Powercord/plugins/pc-updater/index.js
@@ -246,26 +246,26 @@ module.exports = class Updater extends Plugin {
   }
 
   async getGitInfos () {
-    const branch = await exec('git branch', this.cwd)
-      .then(({ stdout }) =>
-        stdout
-          .toString()
-          .split('\n')
-          .find(l => l.startsWith('*'))
-          .slice(2)
-          .trim()
-      );
-
-    const revision = await exec(`git rev-parse ${branch}`, this.cwd)
+    const revision = await exec('git rev-parse HEAD', this.cwd)
       .then(r => r.stdout.toString().trim());
 
-    const upstream = await exec('git remote get-url origin', this.cwd)
-      .then(r => r.stdout.toString().match(/github\.com[:/]([\w-_]+\/[\w-_]+)/)[1]);
+    const branch = await exec('git branch --show-current', this.cwd)
+      .then(r => r.stdout.toString().trim() || null);
+
+    const remote = branch
+      ? await exec(`git config branch.${branch}.remote`, this.cwd)
+        .then(r => r.stdout.toString().trim() || null)
+      : null;
+
+    const upstream = remote
+      ? await exec(`git remote get-url ${remote}`, this.cwd)
+        .then(r => r.stdout.toString().match(/github\.com[:/]([\w-_]+\/[\w-_]+)/)[1])
+      : null;
 
     return {
-      upstream,
+      revision,
       branch,
-      revision
+      upstream
     };
   }
 


### PR DESCRIPTION
Properly get revision when not on a branch (previously would fail and just display `???`)
Allow branch and upstream to be null
![Screenshot on 2022-07-19 at 13 13 16](https://user-images.githubusercontent.com/14863373/179820228-c1f60ea2-de14-49e2-b979-18e393521c5f.png)
![Screenshot on 2022-07-19 at 13 13 28](https://user-images.githubusercontent.com/14863373/179820239-e93914b6-dd0a-4c33-88d1-1034f204af49.png)
