### PR TITLE
Use permanent invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # READ FIRST
-This project has reached EOL, which means that no new features will be developed. We're only merging bug fixes and/or security pull requests. You can read more about this decision by joining our [official Discord server](https://discord.gg/powercord).
+This project has reached EOL, which means that no new features will be developed. We're only merging bug fixes and/or security pull requests. You can read more about this decision by joining our [official Discord server](https://discord.gg/VdHUGYcqKS).
 
 # Installation
 See the [installation page of the Powercord Wiki](https://github.com/powercord-org/powercord/wiki/Installation).


### PR DESCRIPTION
The vanity will probably eventually disappear as the server loses boosters due to it being archived. This is just fixing the problem before it happens.